### PR TITLE
Учесть использование MediaQueryList в Safari < 14

### DIFF
--- a/src/helpers/__test__/media-query-list.test.ts
+++ b/src/helpers/__test__/media-query-list.test.ts
@@ -1,0 +1,68 @@
+import { subscribe } from '../media-query-list';
+
+describe('subscribe', () => {
+  it('should handle "addEventListener/removeEventListener" method missing', () => {
+    const fakeMql = {
+      matches: false,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    };
+
+    const spy = jest.fn();
+
+    expect(fakeMql.addListener).toBeCalledTimes(0);
+    expect(fakeMql.removeListener).toBeCalledTimes(0);
+
+    const { unsubscribe } = subscribe(fakeMql as any, spy);
+
+    expect(fakeMql.addListener).toBeCalledTimes(1);
+    expect(fakeMql.removeListener).toBeCalledTimes(0);
+    expect(fakeMql.addListener.mock.calls[0][0]).toBe(spy);
+
+    unsubscribe();
+
+    expect(fakeMql.addListener).toBeCalledTimes(1);
+    expect(fakeMql.removeListener).toBeCalledTimes(1);
+    expect(fakeMql.removeListener.mock.calls[0][0]).toBe(spy);
+  });
+
+  it('should handle event target method missing', () => {
+    const fakeMql = {
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    const spy = jest.fn();
+
+    expect(fakeMql.addEventListener).toBeCalledTimes(0);
+    expect(fakeMql.removeEventListener).toBeCalledTimes(0);
+
+    const { unsubscribe } = subscribe(fakeMql as any, spy);
+
+    expect(fakeMql.addEventListener).toBeCalledTimes(1);
+    expect(fakeMql.removeEventListener).toBeCalledTimes(0);
+    expect(fakeMql.addEventListener.mock.calls[0][0]).toBe('change');
+    expect(fakeMql.addEventListener.mock.calls[0][1]).toBe(spy);
+
+    unsubscribe();
+
+    expect(fakeMql.addEventListener).toBeCalledTimes(1);
+    expect(fakeMql.removeEventListener).toBeCalledTimes(1);
+    expect(fakeMql.removeEventListener.mock.calls[0][0]).toBe('change');
+    expect(fakeMql.removeEventListener.mock.calls[0][1]).toBe(spy);
+  });
+
+  it('should handle missing all methods', () => {
+    const fakeMql = {
+      matches: false,
+    };
+
+    expect(() => {
+      const spy = jest.fn();
+      const { unsubscribe } = subscribe(fakeMql as any, spy);
+
+      unsubscribe();
+    }).not.toThrow();
+  });
+});

--- a/src/helpers/media-query-list.ts
+++ b/src/helpers/media-query-list.ts
@@ -1,0 +1,26 @@
+/**
+ * Подписка на изменение MediaQueryList с учетом запуска в Safari < 14.
+ * @param mql MediaQueryList.
+ * @param fn Обработчик.
+ * @return Интерфейс отписки.
+ */
+export const subscribe = (
+  mql: MediaQueryList,
+  fn: (e: MediaQueryListEvent) => void,
+): { unsubscribe: () => void } => {
+  if (mql.addEventListener) {
+    mql.addEventListener('change', fn);
+  } else if (mql.addListener) {
+    mql.addListener(fn);
+  }
+
+  return {
+    unsubscribe: () => {
+      if (mql.removeEventListener) {
+        mql.removeEventListener('change', fn);
+      } else if (mql.removeListener) {
+        mql.removeListener(fn);
+      }
+    },
+  };
+};

--- a/src/hooks/breakpoint/utils.ts
+++ b/src/hooks/breakpoint/utils.ts
@@ -1,3 +1,4 @@
+import { subscribe } from '../../helpers/media-query-list';
 import {
   Breakpoint,
   ChangeHandler,
@@ -19,17 +20,7 @@ const Resolution: Record<Breakpoint, number> = {
   xl: 1920,
 } as const;
 
-const BREAKPOINTS: ReadonlyArray<Breakpoint> = [
-  'mxs',
-  'ms',
-  'mm',
-  'ml',
-  'xs',
-  's',
-  'm',
-  'l',
-  'xl',
-];
+const BREAKPOINTS: ReadonlyArray<Breakpoint> = ['mxs', 'ms', 'mm', 'ml', 'xs', 's', 'm', 'l', 'xl'];
 
 export const BreakpointQuery = {
   getBreakpoint: (query: string) => query.slice(0, -1),
@@ -71,7 +62,8 @@ export const createRegistry = (): Registry => {
           handlers: new Set([listener]),
         };
 
-        newItem.mql.addEventListener('change', e => {
+        // не предусматриваем отписку и удаление mql за ненадобностью
+        subscribe(newItem.mql, e => {
           newItem.handlers.forEach(fn => fn(e));
         });
 
@@ -87,10 +79,7 @@ export const createRegistry = (): Registry => {
 };
 
 // eslint-disable-next-line require-jsdoc
-const createSubscription = (
-  item: RegistryItem,
-  listener: ChangeHandler,
-): Subscription => ({
+const createSubscription = (item: RegistryItem, listener: ChangeHandler): Subscription => ({
   matches: item.mql.matches,
   unsubscribe: () => item.handlers.delete(listener),
 });

--- a/src/hooks/media.ts
+++ b/src/hooks/media.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import on from '../helpers/on';
+import { subscribe } from '../helpers/media-query-list';
 
 /**
  * Возвращает состояние по media-запросу.
@@ -14,9 +14,9 @@ export const useMedia = (query: string) => {
 
     setMatches(mql.matches);
 
-    return on<MediaQueryListEvent>(mql, 'change', event => {
+    return subscribe(mql, event => {
       setMatches(event.matches);
-    });
+    }).unsubscribe;
   }, [query]);
 
   return matches;


### PR DESCRIPTION
- добавлена утилитарная функция для подписки на событие `change` объекта `MediaQueryList` с учетом запуска в Safari < 14
- задействована новая функция подписки в хуках `useMedia` и `useBreakpoint`

Closes #42 