### PR TITLE
WithTooltip: тултип выпадает за пределы Modal при отсутствии прокрутки у модального окна

### DIFF
--- a/src/_internal/body-scroll.ts
+++ b/src/_internal/body-scroll.ts
@@ -2,12 +2,11 @@ import { disableBodyScroll, enableBodyScroll, BodyScrollOptions } from 'body-scr
 import { useEffect } from 'react';
 
 export interface WithBodyScrollLock {
-
   /** Нужно ли выключать прокрутку body. */
-  withScrollDisable?: boolean
+  withScrollDisable?: boolean;
 
   /** Опции отключения прокрутки. */
-  scrollDisableOptions?: BodyScrollOptions
+  scrollDisableOptions?: BodyScrollOptions;
 }
 
 /**
@@ -17,9 +16,9 @@ export interface WithBodyScrollLock {
  * @param options Опции.
  */
 export const useBodyScrollLock = (
-  ref: React.RefObject<HTMLElement | null>,
+  ref: React.RefObject<HTMLElement>,
   needDisable: boolean | undefined,
-  options?: BodyScrollOptions
+  options?: BodyScrollOptions,
 ): void => {
   useEffect(() => {
     const element = ref.current;

--- a/src/context/viewport.ts
+++ b/src/context/viewport.ts
@@ -1,0 +1,7 @@
+import { createRef, RefObject, createContext } from 'react';
+
+/**
+ * Контекст необходимый для правильного позиционирования выпадающих элементов (например Tooltip)
+ * внутри компонентов формирующих свою область видимости (например Modal).
+ */
+export const ViewportContext = createContext<RefObject<HTMLElement>>(createRef());

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -15,41 +15,40 @@ import { WithBodyScrollLock, useBodyScrollLock } from '../_internal/body-scroll'
 type ModalSize = 's' | 'm' | 'l' | 'xl' | 'fullscreen';
 
 interface ModalStyle extends React.CSSProperties {
-  '--modal-height'?: string
-  '--header-height': string
-  '--footer-height': string
+  '--modal-height'?: string;
+  '--header-height': string;
+  '--footer-height': string;
 }
 
 export interface ModalProps extends WithBodyScrollLock {
-
   /** Содержимое компонента. */
-  children?: React.ReactNode
+  children?: React.ReactNode;
 
   /** Высота в пикселях. */
-  height?: number
+  height?: number;
 
   /** Будет вызвана при нажатии на кнопку "назад" в топ баре. */
-  onBack?: () => void
+  onBack?: () => void;
 
   /** Будет вызвана при закрытии окна. */
-  onClose?: () => void
+  onClose?: () => void;
 
   /** Размер окна. */
-  size?: ModalSize
+  size?: ModalSize;
 
-  /** Нужно ли выводить элемент в Layer (при SSR необходимо указать false). */
-  inPortal?: boolean
+  /** Нужно ли выводить элемент в портале (для SSR следует указывать false). */
+  inPortal?: boolean;
 
   /** Идентификатор для систем автоматизированного тестирования. */
-  'data-testid'?: string
+  'data-testid'?: string;
 }
 
 export interface ModalComponent {
-  (props: ModalProps): JSX.Element
-  Header: typeof ModalHeader
-  Body: typeof ModalBody
-  Footer: typeof ModalFooter
-  Overlap: typeof ModalOverlap
+  (props: ModalProps): JSX.Element;
+  Header: typeof ModalHeader;
+  Body: typeof ModalBody;
+  Footer: typeof ModalFooter;
+  Overlap: typeof ModalOverlap;
 }
 
 const cx = classnames.bind(styles);
@@ -100,9 +99,7 @@ const ModalInner = ({
 
   const topBarSize: TopBarSize = fullscreen ? 'm' : 's';
 
-  const headerHeight: number = header
-    ? TOP_BAR_HEIGHT[topBarSize]
-    : 0;
+  const headerHeight: number = header ? TOP_BAR_HEIGHT[topBarSize] : 0;
 
   const footerStubHeight: number = fullscreen ? 0 : 16;
 
@@ -127,33 +124,25 @@ const ModalInner = ({
       {...handleClose}
     >
       <div
-        className={cx(
-          'modal',
-          `size-${size}`,
-          !fullscreen && BoxShadow.z4
-        )}
+        className={cx('modal', `size-${size}`, !fullscreen && BoxShadow.z4)}
         style={style}
         data-testid={testId}
       >
-        {header && cloneElement<ModalHeaderProps>(header, {
-          size: topBarSize,
-        })}
+        {header &&
+          cloneElement<ModalHeaderProps>(header, {
+            size: topBarSize,
+          })}
 
-        <LayerProvider value={layer}>
-          {content}
-        </LayerProvider>
+        <LayerProvider value={layer}>{content}</LayerProvider>
 
-        {footer && cloneElement<BottomBarProps>(footer, {
-          size: fullscreen ? 'l' : footer.props.size,
-        })}
+        {footer &&
+          cloneElement<BottomBarProps>(footer, {
+            size: fullscreen ? 'l' : footer.props.size,
+          })}
 
-        {!footer && !fullscreen && (
-          <div className={cx('footer-stub')} />
-        )}
+        {!footer && !fullscreen && <div className={cx('footer-stub')} />}
 
-        {!fullscreen && overlap && (
-          <div className={cx('overlap')}>{overlap}</div>
-        )}
+        {!fullscreen && overlap && <div className={cx('overlap')}>{overlap}</div>}
       </div>
     </div>
   );

--- a/src/modal/modal.module.scss
+++ b/src/modal/modal.module.scss
@@ -68,8 +68,7 @@ $max-height: 696px;
 .body {
   flex-grow: 1;
   max-height: calc(
-    var(--modal-height, #{$max-height}) - var(--header-height) -
-      var(--footer-height)
+    var(--modal-height, #{$max-height}) - var(--header-height) - var(--footer-height)
   );
 }
 

--- a/src/modal/slots.tsx
+++ b/src/modal/slots.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { TopBar, TopBarProps } from '../top-bar';
 import CrossSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/cross';
 import ArrowLeftSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/arrow-left';
 import { BottomBar, BottomBarProps } from '../bottom-bar';
 import { CustomScrollbar } from '../_internal/custom-scrollbar';
 import styles from './modal.module.scss';
+import { ViewportContext } from '../context/viewport';
 
 export interface ModalHeaderProps extends TopBarProps {
-  onBack?: () => void
-  onClose?: () => void
+  onBack?: () => void;
+  onClose?: () => void;
 }
 
 /**
@@ -16,29 +17,25 @@ export interface ModalHeaderProps extends TopBarProps {
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalHeader = ({
-  onBack,
-  onClose,
-  ...topBarProps
-}: ModalHeaderProps) => (
+export const ModalHeader = ({ onBack, onClose, ...topBarProps }: ModalHeaderProps) => (
   <TopBar
     {...topBarProps}
     buttonsProps={{
       ...topBarProps.buttonsProps,
-      ...onBack && {
+      ...(onBack && {
         start: {
           'data-testid': 'modal:back',
           onClick: onBack,
           icon: <ArrowLeftSVG />,
         },
-      },
-      ...onClose && {
+      }),
+      ...(onClose && {
         end: {
           'data-testid': 'modal:close',
           onClick: onClose,
           icon: <CrossSVG />,
         },
-      },
+      }),
     }}
     className={styles.header}
   />
@@ -49,41 +46,44 @@ export const ModalHeader = ({
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalBody: React.FC<{
-  onFullScroll?: () => void
-  fullScrollThreshold?: number
-}> = ({
+export const ModalBody = ({
   children,
   onFullScroll,
   fullScrollThreshold,
-}) => (
-  <CustomScrollbar
-    inFlexBox
-    className={styles.body}
-    overflow={{ x: 'h', y: 's' }}
-    onFullScroll={onFullScroll}
-    fullScrollThreshold={fullScrollThreshold}
-  >
-    <div className={styles.main}>
-      {children}
-    </div>
-  </CustomScrollbar>
-);
+}: {
+  children?: React.ReactNode;
+  fullScrollThreshold?: number;
+  onFullScroll?: () => void;
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <CustomScrollbar
+      inFlexBox
+      className={styles.body}
+      overflow={{ x: 'h', y: 's' }}
+      onFullScroll={onFullScroll}
+      fullScrollThreshold={fullScrollThreshold}
+    >
+      <ViewportContext.Provider value={ref}>
+        <div className={styles.main} ref={ref}>
+          {children}
+        </div>
+      </ViewportContext.Provider>
+    </CustomScrollbar>
+  );
+};
 
 /**
  * Футер окна.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalFooter = (props: BottomBarProps) => (
-  <BottomBar {...props} />
-);
+export const ModalFooter = (props: BottomBarProps) => <BottomBar {...props} />;
 
 /**
  * Контент который будет выводится поверх окна с абсолютным позиционированием.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalOverlap: React.FC = ({ children }) => (
-  <>{children}</>
-);
+export const ModalOverlap: React.FC = ({ children }) => <>{children}</>;

--- a/src/tooltip/__stories__/index.stories.tsx
+++ b/src/tooltip/__stories__/index.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import React from 'react';
 import { Tooltip } from '..';
 
@@ -23,6 +24,6 @@ export default {
   },
 };
 
-export const Primary = () => <Tooltip>{shortText}</Tooltip>;
+export const Primary = () => <Tooltip onClose={() => action('onClose')()}>{shortText}</Tooltip>;
 
-export const LargeContent = () => <Tooltip>{longText}</Tooltip>;
+export const LargeContent = () => <Tooltip onClose={() => action('onClose')()}>{longText}</Tooltip>;

--- a/src/with-tooltip/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/with-tooltip/__test__/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`WithTooltip should works correctly 1`] = `
     <div
       class="root"
       data-testid="tooltip"
-      style="position: absolute; top: 0px; left: 0px; z-index: 1; transform: translate3d(0px, 0px, 0);"
+      style="position: absolute; top: 0px; left: 0px; opacity: 1; z-index: 1; max-height: -32px; transform: translate3d(16px, 16px, 0);"
     >
       <svg
         class="cross"

--- a/src/with-tooltip/__test__/utils.test.ts
+++ b/src/with-tooltip/__test__/utils.test.ts
@@ -95,7 +95,7 @@ describe('CanPlace', () => {
   });
 
   it('onTop', () => {
-    let holderEl = FakeElement.withRect({ bottom: 500 }) as any;
+    let holderEl = FakeElement.withRect({ top: 500 }) as any;
     let tooltipEl = FakeElement.withRect({ height: 100 }) as any;
 
     expect(CanPlace.onTop(holderEl, tooltipEl, testArea)).toBe(true);
@@ -290,33 +290,55 @@ describe('placeTooltip', () => {
   it('should place on right', () => {
     const holderEl = FakeElement.withRect({
       width: 10,
-      height: 980,
-      left: 10,
-      right: 20,
+      height: 10,
       top: 10,
-      bottom: 990,
+      left: 10,
+      bottom: 20,
+      right: 20,
     });
-    const tooltipEl = FakeElement.withRect({ width: 100, height: 100 });
 
-    placeTooltip(tooltipEl, holderEl);
+    const tooltipEl = FakeElement.withRect({
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      bottom: 100,
+      right: 100,
+    });
 
-    expect(tooltipEl.style.transform).toEqual('translate3d(28px, 890px, 0)');
+    const viewportEl = FakeElement.withRect({
+      width: 1000,
+      height: 1000,
+      right: 1000,
+      bottom: 1000,
+    });
+
+    placeTooltip(tooltipEl, holderEl, viewportEl);
+
+    expect(tooltipEl.style.transform).toEqual('translate3d(28px, 10px, 0)');
   });
 
   it('should place on left', () => {
     const holderEl = FakeElement.withRect({
       width: 10,
-      height: 980,
+      height: 10,
       left: 980,
       right: 990,
       top: 10,
-      bottom: 990,
+      bottom: 20,
     });
     const tooltipEl = FakeElement.withRect({ width: 100, height: 100 });
 
-    placeTooltip(tooltipEl, holderEl);
+    const viewportEl = FakeElement.withRect({
+      width: 1000,
+      height: 1000,
+      right: 1000,
+      bottom: 1000,
+    });
 
-    expect(tooltipEl.style.transform).toEqual('translate3d(872px, 890px, 0)');
+    placeTooltip(tooltipEl, holderEl, viewportEl);
+
+    expect(tooltipEl.style.transform).toEqual('translate3d(872px, 10px, 0)');
   });
 
   it('should place on bottom', () => {
@@ -330,7 +352,14 @@ describe('placeTooltip', () => {
     });
     const tooltipEl = FakeElement.withRect({ height: 100, width: 100 });
 
-    placeTooltip(tooltipEl, holderEl);
+    const viewportEl = FakeElement.withRect({
+      width: 1000,
+      height: 1000,
+      right: 1000,
+      bottom: 1000,
+    });
+
+    placeTooltip(tooltipEl, holderEl, viewportEl);
 
     expect(tooltipEl.style.transform).toEqual('translate3d(16px, 28px, 0)');
   });
@@ -346,19 +375,40 @@ describe('placeTooltip', () => {
     });
     const tooltipEl = FakeElement.withRect({ height: 100, width: 100 });
 
-    placeTooltip(tooltipEl, holderEl);
+    const viewportEl = FakeElement.withRect({
+      width: 1000,
+      height: 1000,
+      right: 1000,
+      bottom: 1000,
+    });
+
+    placeTooltip(tooltipEl, holderEl, viewportEl);
 
     expect(tooltipEl.style.transform).toEqual('translate3d(16px, 872px, 0)');
   });
 
-  it('should do nothing when tooltip or holder is not defined', () => {
-    const holderEl = FakeElement.create();
-    const tooltipEl = FakeElement.create();
+  it('should place at left top corner when no more space', () => {
+    const holderEl = FakeElement.withRect({
+      width: 980,
+      height: 980,
+      top: 10,
+      left: 10,
+      bottom: 990,
+      right: 990,
+    });
+    const tooltipEl = FakeElement.withRect({ height: 100, width: 100 });
 
-    expect(() => {
-      placeTooltip(null as any, holderEl);
-      placeTooltip(tooltipEl, null as any);
-    }).not.toThrow();
+    const viewportEl = FakeElement.withRect({
+      width: 1000,
+      height: 1000,
+      bottom: 1000,
+      right: 1000,
+    });
+
+    placeTooltip(tooltipEl, holderEl, viewportEl);
+
+    expect(tooltipEl.style.transform).toEqual('translate3d(16px, 16px, 0)');
+    expect(tooltipEl.style.maxHeight).toEqual('968px');
   });
 });
 

--- a/src/with-tooltip/positioning-tooltip.tsx
+++ b/src/with-tooltip/positioning-tooltip.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useContext } from 'react';
+import { ViewportContext } from '../context/viewport';
 import { debounce } from 'lodash';
 import { getScrollParent } from '../helpers/get-scroll-parent';
 import { placeTooltip } from './utils';
@@ -26,13 +27,18 @@ export interface PositioningTooltipProps {
 export const PositioningTooltip = ({ openerRef, children, onDismiss }: PositioningTooltipProps) => {
   const layer = useLayer();
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useContext(ViewportContext);
 
   const place = useCallback(() => {
     if (tooltipRef.current && openerRef.current) {
-      placeTooltip(tooltipRef.current, openerRef.current);
-      tooltipRef.current.style.opacity = '';
+      placeTooltip(
+        tooltipRef.current,
+        openerRef.current,
+        viewportRef.current || getScrollParent(tooltipRef.current),
+      );
+      tooltipRef.current.style.opacity = '1';
     }
-  }, [openerRef]);
+  }, [openerRef, viewportRef]);
 
   useEffect(place);
 


### PR DESCRIPTION
- добавлен контекст для передачи элемента, формирующего viewport для выпадающих элементов
- задействован новый контекст в `Modal.Body`
- правки типов `useBodyScrollLock`
- мелкие правки stories `Tooltip`
- правки позиционирования тултипа в `WithTooltip`

Closes #41 
