### PR TITLE
#64 NavBar: кнопки-заглушки теперь игнорируют свойства оригиналов

### DIFF
--- a/src/nav-bar/__test__/index.test.tsx
+++ b/src/nav-bar/__test__/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 import { NavBar } from '..';
 import ArrowLeftSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/arrow-left';
 import CrossSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/cross';
@@ -8,24 +9,13 @@ import PersonSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/person';
 
 describe('<NavBar />', () => {
   it('should render just title and subtitle', () => {
-    const wrapper = mount(
-      <NavBar
-        title='Hello'
-        subtitle='World'
-      />
-    );
+    const wrapper = mount(<NavBar title='Hello' subtitle='World' />);
 
     expect(wrapper).toMatchSnapshot();
   });
 
   it('should handle "bottomBordered" prop', () => {
-    const wrapper = mount(
-      <NavBar
-        title='Hello'
-        subtitle='World'
-        bottomBordered
-      />
-    );
+    const wrapper = mount(<NavBar title='Hello' subtitle='World' bottomBordered />);
 
     expect(wrapper).toMatchSnapshot();
   });
@@ -38,7 +28,7 @@ describe('<NavBar />', () => {
         buttons={{
           start: { text: 'Foo' },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -52,7 +42,7 @@ describe('<NavBar />', () => {
         buttons={{
           startSecondary: { text: 'Foo' },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -66,7 +56,7 @@ describe('<NavBar />', () => {
         buttons={{
           end: { text: 'Bar' },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -80,7 +70,7 @@ describe('<NavBar />', () => {
         buttons={{
           endSecondary: { text: 'Bar' },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -95,7 +85,7 @@ describe('<NavBar />', () => {
           start: { text: 'Foo' },
           end: { text: 'Bar' },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -109,7 +99,7 @@ describe('<NavBar />', () => {
         buttons={{
           start: { icon: ArrowLeftSVG },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -123,7 +113,7 @@ describe('<NavBar />', () => {
         buttons={{
           end: { icon: ArrowLeftSVG },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -138,7 +128,7 @@ describe('<NavBar />', () => {
           start: { icon: ArrowLeftSVG },
           end: { icon: CrossSVG },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -155,7 +145,7 @@ describe('<NavBar />', () => {
           end: { icon: CrossSVG },
           endSecondary: { icon: PersonSVG },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -170,9 +160,25 @@ describe('<NavBar />', () => {
           start: { text: 'Foo' },
           end: { icon: CrossSVG },
         }}
-      />
+      />,
     );
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render stub-buttons without any attributes like "data-testid" or "aria-label"', async () => {
+    const { container, findAllByTestId } = render(
+      <NavBar
+        title='Очень очень очень длинный заголовок'
+        subtitle='Очень очень очень очень длинный подзаголовок'
+        buttons={{
+          start: { text: 'Foo', 'aria-label': 'foo' },
+          end: { icon: CrossSVG, 'data-testid': 'bar' },
+        }}
+      />,
+    );
+
+    expect(container.querySelectorAll('[aria-label="foo"]')).toHaveLength(1);
+    expect(await findAllByTestId('bar')).toHaveLength(1);
   });
 });

--- a/src/nav-bar/index.tsx
+++ b/src/nav-bar/index.tsx
@@ -10,6 +10,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon?: React.ComponentType<React.SVGAttributes<SVGSVGElement>>;
   stub?: boolean;
   shift?: 'left' | 'right';
+  'data-testid'?: string;
 }
 
 export interface NavBarProps {
@@ -141,7 +142,7 @@ export const NavButton: React.FC<ButtonProps> = ({
   ...buttonProps
 }) => (
   <button
-    {...buttonProps}
+    {...(!stub && buttonProps)} // игнорируем атрибуты и свойства для заглушек
     type='button'
     className={cx(
       'button',

--- a/src/screen/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/screen/__test__/__snapshots__/index.test.tsx.snap
@@ -114,7 +114,6 @@ exports[`<Screen /> should handle "loadingArea" prop 1`] = `
                 >
                   <button
                     aria-hidden="true"
-                    aria-label="Закрыть"
                     class="button icon stub"
                     type="button"
                   />
@@ -248,9 +247,7 @@ exports[`<Screen /> should handle "loadingArea" prop 1`] = `
                   >
                     <button
                       aria-hidden={true}
-                      aria-label="Закрыть"
                       className="button icon stub"
-                      onClick={[Function]}
                       type="button"
                     />
                   </NavButton>
@@ -420,7 +417,6 @@ exports[`<Screen /> should handle props 1`] = `
                 >
                   <button
                     aria-hidden="true"
-                    aria-label="Закрыть Test title"
                     class="button icon stub"
                     type="button"
                   />
@@ -478,7 +474,6 @@ exports[`<Screen /> should handle props 1`] = `
                 >
                   <button
                     aria-hidden="true"
-                    aria-label="Вернуться назад"
                     class="button icon stub"
                     type="button"
                   />
@@ -620,9 +615,7 @@ exports[`<Screen /> should handle props 1`] = `
                   >
                     <button
                       aria-hidden={true}
-                      aria-label="Закрыть Test title"
                       className="button icon stub"
-                      onClick={[Function]}
                       type="button"
                     />
                   </NavButton>
@@ -709,9 +702,7 @@ exports[`<Screen /> should handle props 1`] = `
                   >
                     <button
                       aria-hidden={true}
-                      aria-label="Вернуться назад"
                       className="button icon stub"
-                      onClick={[Function]}
                       type="button"
                     />
                   </NavButton>
@@ -758,7 +749,6 @@ exports[`<Screen /> should render without props 1`] = `
                 >
                   <button
                     aria-hidden="true"
-                    aria-label="Закрыть"
                     class="button icon stub"
                     type="button"
                   />
@@ -870,9 +860,7 @@ exports[`<Screen /> should render without props 1`] = `
                   >
                     <button
                       aria-hidden={true}
-                      aria-label="Закрыть"
                       className="button icon stub"
-                      onClick={[Function]}
                       type="button"
                     />
                   </NavButton>


### PR DESCRIPTION
- NavBar: добавлено игнорирование свойств для кнопок-заглушек
- добавлены тесты

Closes #64 