### PR TITLE
#92 UnknownContent: исправить установку отступов на корневой элемент

### DIFF
--- a/src/unknown-content/unknown-content.module.scss
+++ b/src/unknown-content/unknown-content.module.scss
@@ -220,9 +220,9 @@
     display: block;
     max-width: 100%;
     margin-bottom: 32px;
-  }
-  @include breakpoints.up('xs') {
-    margin-bottom: 40px;
+    @include breakpoints.up('xs') {
+      margin-bottom: 40px;
+    }
   }
 
   // цитата


### PR DESCRIPTION
- `UnknownContent`: `margin-bottom` применялся не к `img, media` а к корневому элементу - исправлено

Closes #92 
