### PR TITLE
#114  PhoneInput: убрать stopPropagation для кликов

### DIFF
--- a/src/autocomplete/__stories__/index.stories.tsx
+++ b/src/autocomplete/__stories__/index.stories.tsx
@@ -63,7 +63,7 @@ export const Loading = () => {
   const [loading, setLoading] = useState(false);
 
   return (
-    <div style={{ '--dropdown-max-height': '100px' }}>
+    <>
       <Autocomplete
         preset='filled-only-list'
         value={value}
@@ -81,6 +81,6 @@ export const Loading = () => {
         }}
         onSelect={setValue}
       />
-    </div>
+    </>
   );
 };

--- a/src/autocomplete/__stories__/index.stories.tsx
+++ b/src/autocomplete/__stories__/index.stories.tsx
@@ -63,7 +63,7 @@ export const Loading = () => {
   const [loading, setLoading] = useState(false);
 
   return (
-    <>
+    <div style={{ '--dropdown-max-height': '100px' }}>
       <Autocomplete
         preset='filled-only-list'
         value={value}
@@ -81,6 +81,6 @@ export const Loading = () => {
         }}
         onSelect={setValue}
       />
-    </>
+    </div>
   );
 };

--- a/src/autocomplete/index.tsx
+++ b/src/autocomplete/index.tsx
@@ -74,19 +74,17 @@ export const Autocomplete = ({
   const rootRef = useRef<HTMLDivElement>(null);
   const fieldRef = useRef<HTMLInputElement>();
   const menuRef = useRef<HTMLDivElement>();
-  const [needDropdown, toggleDropdown] = useState(false);
+  const [withMenu, toggleMenu] = useState(false);
   const [realValue, setRealValue] = useState<string | undefined>(value || defaultValue);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
 
   const canShowDropdown =
-    preset === 'filled-only-list'
-      ? needDropdown && realValue && realValue.length > 0
-      : needDropdown;
+    preset === 'filled-only-list' ? withMenu && realValue && realValue.length > 0 : withMenu;
 
   const endAdornment = preset === 'default' ? <DownSVG fill={COLORS.get('gray38')} /> : undefined;
 
   useOutsideClick(rootRef, () => {
-    toggleDropdown(false);
+    toggleMenu(false);
   });
 
   useEffect(() => {
@@ -104,9 +102,9 @@ export const Autocomplete = ({
     if (menu && osInstance && activeIndex !== null) {
       const child = menu.querySelectorAll('[role="menuitem"]')[activeIndex];
 
-      child &&
+      child instanceof HTMLElement &&
         osInstance.scroll({
-          el: child as HTMLElement,
+          el: child,
           scroll: { y: 'ifneeded' },
         });
     }
@@ -122,18 +120,18 @@ export const Autocomplete = ({
       <TextField
         {...restProps}
         ref={fieldRef}
-        focused={needDropdown}
+        focused={withMenu}
         endAdornment={endAdornment}
         data-testid='autocomplete:field'
         variant='desktop'
         value={value}
         multiline={false}
         onClick={e => {
-          toggleDropdown(true);
+          toggleMenu(true);
           onClick && onClick(e);
         }}
         onChange={(e: any) => {
-          toggleDropdown(true);
+          toggleMenu(true);
           setRealValue(e.target.value);
           setActiveIndex(0);
           onChange && onChange(e);
@@ -154,7 +152,7 @@ export const Autocomplete = ({
             case 'Enter':
               if (items && !isNull(activeIndex) && items.length > activeIndex) {
                 onSelect && onSelect(items[activeIndex]);
-                toggleDropdown(false);
+                toggleMenu(false);
               }
               break;
           }
@@ -188,7 +186,7 @@ export const Autocomplete = ({
                     onClick={() => {
                       onSelect && onSelect(item);
                       setActiveIndex(null);
-                      toggleDropdown(false);
+                      toggleMenu(false);
                       fieldRef.current && fieldRef.current.focus();
                     }}
                   >

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import React, { useEffect, useState, useLayoutEffect } from 'react';
 import { isTouchDevice } from '../helpers/is-touch-device';
-import { isFunction } from 'lodash';
 import on from '../helpers/on';
 import { useIdentityRef } from './identity';
 
@@ -63,22 +62,19 @@ export const useOutsideClick = (
   elementRef: React.MutableRefObject<HTMLElement | undefined | null>,
   callback: (e: MouseEvent) => void,
 ) => {
-  const callbackRef = useRef(callback);
-
-  callbackRef.current = callback;
+  const callbackRef = useIdentityRef(callback);
 
   useEffect(
     () =>
-      on(document.documentElement, 'click', (event: MouseEvent) => {
+      on<MouseEvent>(document.documentElement, 'click', event => {
         const { current: element } = elementRef;
         const { current: handleClick } = callbackRef;
 
         element &&
           element !== event.target &&
-          !element.contains(event.target as HTMLElement) &&
-          isFunction(handleClick) &&
-          handleClick(event);
-      }) as () => void,
+          !element.contains(event.target as Node) &&
+          handleClick?.(event);
+      }),
     [],
   );
 };

--- a/src/phone-input/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/phone-input/__test__/__snapshots__/index.test.tsx.snap
@@ -24,8 +24,7 @@ exports[`<PhoneInput /> Other: should render just text field with able to input 
             width={24}
           />
           <ForwardRef(DownSVG)
-            className="M-l__1"
-            fill="#9e9e9e"
+            className="arrow"
           />
         </div>
       }
@@ -33,6 +32,7 @@ exports[`<PhoneInput /> Other: should render just text field with able to input 
       multiline={false}
       onBlur={[Function]}
       onChange={[Function]}
+      onClick={[Function]}
     >
       <div
         className="root field"
@@ -98,12 +98,10 @@ exports[`<PhoneInput /> Other: should render just text field with able to input 
                   width={24}
                 />
                 <ForwardRef(DownSVG)
-                  className="M-l__1"
-                  fill="#9e9e9e"
+                  className="arrow"
                 >
                   <svg
-                    className="M-l__1"
-                    fill="#9e9e9e"
+                    className="arrow"
                     height={16}
                     viewBox="0 0 16 16"
                     width={16}
@@ -145,8 +143,7 @@ exports[`<PhoneInput /> should render without props 1`] = `
             width={24}
           />
           <ForwardRef(DownSVG)
-            className="M-l__1"
-            fill="#9e9e9e"
+            className="arrow"
           />
         </div>
       }
@@ -154,6 +151,7 @@ exports[`<PhoneInput /> should render without props 1`] = `
       mask="+7 (___) ___-__-__"
       multiline={false}
       onBlur={[Function]}
+      onClick={[Function]}
       value=""
     >
       <ForwardRef(TextField)
@@ -171,14 +169,14 @@ exports[`<PhoneInput /> should render without props 1`] = `
               width={24}
             />
             <ForwardRef(DownSVG)
-              className="M-l__1"
-              fill="#9e9e9e"
+              className="arrow"
             />
           </div>
         }
         label="Телефон"
         multiline={false}
         onBlur={[Function]}
+        onClick={[Function]}
         restPlaceholder={
           Object {
             "shiftValue": "+7 (",
@@ -271,12 +269,10 @@ exports[`<PhoneInput /> should render without props 1`] = `
                     width={24}
                   />
                   <ForwardRef(DownSVG)
-                    className="M-l__1"
-                    fill="#9e9e9e"
+                    className="arrow"
                   >
                     <svg
-                      className="M-l__1"
-                      fill="#9e9e9e"
+                      className="arrow"
                       height={16}
                       viewBox="0 0 16 16"
                       width={16}

--- a/src/phone-input/__test__/index.test.tsx
+++ b/src/phone-input/__test__/index.test.tsx
@@ -7,7 +7,7 @@ import { Dropdown } from '../../dropdown';
 import { DropdownItem } from '../../dropdown-item';
 import { MaskedField } from '../../masked-field';
 import { countries } from '../presets';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('<PhoneInput />', () => {
   it('should render without props', () => {
@@ -144,5 +144,48 @@ describe('<PhoneInput />', () => {
     const { getByTestId } = render(<PhoneInput value='0000000' label='My Phone' />);
 
     expect(getByTestId('text-field:label').textContent).toBe('My Phone');
+  });
+
+  it('should handle field block click: opener click case', () => {
+    const { getByTestId } = render(<PhoneInput value='' onBlur={jest.fn()} />);
+
+    const event = new MouseEvent('click', { bubbles: true });
+    jest.spyOn(event, 'preventDefault');
+
+    expect(event.preventDefault).toBeCalledTimes(0);
+    fireEvent(getByTestId('phone-input:dropdown-opener'), event);
+    expect(event.preventDefault).toBeCalledTimes(1);
+  });
+
+  it('should handle field block click: inside opener click case', () => {
+    const { container } = render(<PhoneInput value='' onBlur={jest.fn()} />);
+
+    const event = new MouseEvent('click', { bubbles: true });
+    jest.spyOn(event, 'preventDefault');
+
+    expect(event.preventDefault).toBeCalledTimes(0);
+    fireEvent(
+      container.querySelector('[data-testid="phone-input:dropdown-opener"] > img') as any,
+      event,
+    );
+    expect(event.preventDefault).toBeCalledTimes(1);
+  });
+
+  it('should handle field block click: block click case', () => {
+    const { getByTestId, queryAllByTestId } = render(<PhoneInput value='' onBlur={jest.fn()} />);
+
+    // show dropdown menu
+    expect(queryAllByTestId('phone-input:dropdown')).toHaveLength(0);
+    fireEvent.click(getByTestId('phone-input:dropdown-opener'));
+    expect(queryAllByTestId('phone-input:dropdown')).toHaveLength(1);
+
+    const event = new MouseEvent('click', { bubbles: true });
+    jest.spyOn(event, 'preventDefault');
+
+    expect(queryAllByTestId('phone-input:dropdown')).toHaveLength(1);
+    expect(event.preventDefault).toBeCalledTimes(0);
+    fireEvent(getByTestId('text-field:block'), event);
+    expect(queryAllByTestId('phone-input:dropdown')).toHaveLength(0);
+    expect(event.preventDefault).toBeCalledTimes(0);
   });
 });

--- a/src/phone-input/phone-input.module.scss
+++ b/src/phone-input/phone-input.module.scss
@@ -17,7 +17,14 @@
   cursor: pointer;
 }
 
-.popup {
+.arrow {
+  display: block;
+  fill: colors.$gray38;
+  margin-left: 4px;
+  pointer-events: none; // игнорируем клики т.к. после них элемент стрелки подменяется и считается что он сработал вне элемента родителя
+}
+
+.menu {
   position: absolute;
   width: 100%;
   top: 56px;
@@ -25,7 +32,7 @@
   z-index: 2;
 }
 
-.popup-item {
+.menu-item {
   font-size: 16px;
   line-height: 24px;
   .item-name {

--- a/src/select/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/select/__test__/__snapshots__/index.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`Select should render loading state 1`] = `
       }
       blockProps={
         Object {
-          "onClick": [Function],
           "onKeyDown": [Function],
           "onMouseDown": [Function],
           "ref": Object {
@@ -95,6 +94,7 @@ exports[`Select should render loading state 1`] = `
       focused={true}
       label="Формат каталога"
       multiline={false}
+      onClick={[Function]}
       readOnly={true}
       value="Карточки товаров JPG"
       variant="desktop"
@@ -367,7 +367,6 @@ exports[`Select should renders correctly 1`] = `
       }
       blockProps={
         Object {
-          "onClick": [Function],
           "onKeyDown": [Function],
           "onMouseDown": [Function],
           "ref": Object {
@@ -433,6 +432,7 @@ exports[`Select should renders correctly 1`] = `
       focused={false}
       label="Формат каталога"
       multiline={false}
+      onClick={[Function]}
       readOnly={true}
       value="Карточки товаров JPG"
       variant="desktop"
@@ -588,7 +588,6 @@ exports[`Select should renders correctly 2`] = `
       }
       blockProps={
         Object {
-          "onClick": [Function],
           "onKeyDown": [Function],
           "onMouseDown": [Function],
           "ref": Object {
@@ -654,6 +653,7 @@ exports[`Select should renders correctly 2`] = `
       focused={true}
       label="Формат каталога"
       multiline={false}
+      onClick={[Function]}
       readOnly={true}
       value="Карточки товаров JPG"
       variant="desktop"

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -98,10 +98,10 @@ export const Select = ({
           onKeyDown: e => {
             e.key === 'Enter' && toggleMenu(true);
           },
-          onClick: e => {
-            e.preventDefault();
-            onClick && onClick(e);
-          },
+        }}
+        onClick={e => {
+          e.preventDefault();
+          onClick && onClick(e);
         }}
         className={styles.field}
         data-testid='select:field'

--- a/src/text-field/__test__/index.test.tsx
+++ b/src/text-field/__test__/index.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react-dom/test-utils';
 import { TextField } from '..';
 import { BaseInput } from '../../base-input';
 import { fitElementHeight } from '../../helpers/fit-element-height';
+import { render } from '@testing-library/react';
 
 jest.mock('../../helpers/fit-element-height', () => {
   const original = jest.requireActual('../../helpers/fit-element-height');
@@ -206,5 +207,17 @@ describe('<TextField />', () => {
 
     expect(fakeRef).toHaveBeenCalled();
     expect(fakeRef.mock.calls[0][0].nodeName).toBe('INPUT');
+  });
+  it('should handle blockProps prop', () => {
+    const { getByTestId } = render(
+      <TextField
+        value='Hello'
+        onChange={jest.fn()}
+        blockProps={{ className: 'test-block-class', id: 'test-block-id' }}
+      />,
+    );
+
+    expect(getByTestId('text-field:block').id).toBe('test-block-id');
+    expect(getByTestId('text-field:block').className).toContain('test-block-class');
   });
 });

--- a/src/text-field/index.tsx
+++ b/src/text-field/index.tsx
@@ -83,7 +83,7 @@ export interface TextFieldProps
   variant?: Variant;
 
   /** Свойства элемента-блока. */
-  blockProps?: React.HTMLProps<HTMLDivElement>;
+  blockProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>;
 
   /** Идентификатор для систем автоматизированного тестирования. */
   'data-testid'?: string;
@@ -192,12 +192,13 @@ export const TextField = forwardRef<
 
   useImperativeHandle(ref, () => baseInputRef.current);
 
-  useEffect(() => toggleHasValue(Boolean((baseInputRef.current as any).value)));
+  useEffect(() => toggleHasValue(Boolean(baseInputRef.current?.value)));
 
   return (
     <div data-testid={dataTestId} className={cx('root', className, classes.root)} style={style}>
       {/* field row */}
       <div
+        {...blockProps}
         data-testid='text-field:block'
         className={cx(
           'reset',
@@ -221,7 +222,6 @@ export const TextField = forwardRef<
             input !== document.activeElement &&
             input.focus();
         }}
-        {...blockProps}
       >
         {/* start adornment column */}
         {!multiline && Boolean(startAdornment) && (

--- a/src/text-field/index.tsx
+++ b/src/text-field/index.tsx
@@ -83,7 +83,7 @@ export interface TextFieldProps
   variant?: Variant;
 
   /** Свойства элемента-блока. */
-  blockProps?: Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>;
+  blockProps?: Omit<React.HTMLProps<HTMLDivElement>, 'onClick'>;
 
   /** Идентификатор для систем автоматизированного тестирования. */
   'data-testid'?: string;


### PR DESCRIPTION
- `PhoneInput`: убран `stopPropagation()` т.к. он из-за него не закрывались меню у других полей на странице (patch)
- `useOutsideClick`: мелкие правки типов (patch)
- `TextField`: разворот `blockProps` перенесен так чтобы не было возможности подменить свойства (minor)
- `Select`: правки после обновления `TextField` (patch)

Closes #114 