### PR TITLE
#141  Modal: исправить блокировку прокрутки

### DIFF
--- a/src/modal/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/modal/__test__/__snapshots__/index.test.tsx.snap
@@ -156,6 +156,7 @@ exports[`<Modal /> should handle extended props 1`] = `
             >
               <div
                 class="main"
+                data-bsl-ignore="true"
               >
                 Main Content
               </div>
@@ -454,6 +455,7 @@ exports[`<Modal /> should render overlap content 1`] = `
             >
               <div
                 class="main"
+                data-bsl-ignore="true"
               >
                 This is modal body
               </div>

--- a/src/modal/__test__/index.test.tsx
+++ b/src/modal/__test__/index.test.tsx
@@ -3,6 +3,7 @@ import { Modal } from '..';
 import ArrowLeftSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/arrow-left';
 import { useBodyScrollLock } from '../../_internal/body-scroll';
 import { render, fireEvent } from '@testing-library/react';
+import { BSL_IGNORE_ATTR } from '../../constants';
 
 jest.mock('../../_internal/body-scroll', () => {
   const original = jest.requireActual('../../_internal/body-scroll');
@@ -156,5 +157,15 @@ describe('<Modal />', () => {
 
     expect(container.querySelectorAll('[data-testid="modal"]')).toHaveLength(0);
     expect(container.querySelectorAll('[data-testid="some-modal"]')).toHaveLength(1);
+  });
+
+  it('should has attribute for BSL work', () => {
+    const { container } = render(
+      <Modal data-testid='some-modal'>
+        <Modal.Body>Main Content</Modal.Body>
+      </Modal>,
+    );
+
+    expect(container.querySelectorAll(`[${BSL_IGNORE_ATTR}]`)).toHaveLength(1);
   });
 });

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -6,10 +6,10 @@ import { BoxShadow } from '../styling/shadows';
 import { isNumber } from 'lodash';
 import { ModalBody, ModalFooter, ModalHeader, ModalHeaderProps, ModalOverlap } from './slots';
 import { LayerProvider, useLayer } from '../helpers/layer';
+import { defineSlots } from '../helpers/define-slots';
+import { WithBodyScrollLock, useBodyScrollLock, allowTouchMove } from '../_internal/body-scroll';
 import classnames from 'classnames/bind';
 import styles from './modal.module.scss';
-import { defineSlots } from '../helpers/define-slots';
-import { WithBodyScrollLock, useBodyScrollLock } from '../_internal/body-scroll';
 
 type ModalSize = 's' | 'm' | 'l' | 'xl' | 'fullscreen';
 
@@ -58,7 +58,7 @@ export const Modal: ModalComponent = ({
   children,
   height,
   onClose,
-  scrollDisableOptions = { reserveScrollBarGap: true },
+  scrollDisableOptions,
   size = 'm',
   withScrollDisable = false,
   'data-testid': testId = 'modal',
@@ -94,7 +94,14 @@ export const Modal: ModalComponent = ({
     '--footer-height': `${footerHeight}px`,
   };
 
-  useBodyScrollLock(rootRef, withScrollDisable, scrollDisableOptions);
+  useBodyScrollLock(rootRef, withScrollDisable, {
+    // defaults
+    reserveScrollBarGap: true,
+    allowTouchMove,
+
+    // defined options
+    ...scrollDisableOptions,
+  });
 
   return (
     <div

--- a/src/modal/slots.tsx
+++ b/src/modal/slots.tsx
@@ -6,6 +6,7 @@ import { BottomBar, BottomBarProps } from '../bottom-bar';
 import { CustomScrollbar } from '../_internal/custom-scrollbar';
 import styles from './modal.module.scss';
 import { ViewportContext } from '../context/viewport';
+import { BSL_IGNORE_ATTR } from '../constants';
 
 export interface ModalHeaderProps extends TopBarProps {
   onBack?: () => void;
@@ -66,7 +67,7 @@ export const ModalBody = ({
       fullScrollThreshold={fullScrollThreshold}
     >
       <ViewportContext.Provider value={ref}>
-        <div className={styles.main} ref={ref}>
+        <div className={styles.main} ref={ref} {...{ [BSL_IGNORE_ATTR]: true }}>
           {children}
         </div>
       </ViewportContext.Provider>


### PR DESCRIPTION
- Modal: слот Body теперь содержить BSL_IGNORE_ATTR
- Modal: по умолчанию содержит опцию allowTouchMove в пропсе bodyScrollLockOptions

Closes #141 