### PR TITLE
#160 Carousel: исправить поведение на мобильных устройствах

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@ build-storybook
 coverage
 
 # Configs
-.jest/
 *.yaml
 *.yml
 

--- a/src/carousel/__stories__/index.stories.tsx
+++ b/src/carousel/__stories__/index.stories.tsx
@@ -249,7 +249,7 @@ export const PreventLinkClickOnDrag = () => (
           style={{
             display: 'block',
             flexShrink: 0,
-            width: '200px',
+            width: 'calc(50% - 8px)',
             height: '320px',
             marginLeft: index ? '16px' : 0,
             borderRadius: '8px',

--- a/src/carousel/__test__/draggable.test.tsx
+++ b/src/carousel/__test__/draggable.test.tsx
@@ -324,4 +324,14 @@ describe('<Draggable />', () => {
     (wrapper.instance() as any).toggleGrabbed(false);
     expect(spy.mock.calls[0][0].isGrabbed()).toBe(false);
   });
+
+  it('isTransitionEnabled() should return value properly', () => {
+    const fake = {
+      hasTransition: false,
+    };
+
+    expect(Draggable.prototype.isTransitionEnabled.call(fake)).toBe(false);
+    fake.hasTransition = true;
+    expect(Draggable.prototype.isTransitionEnabled.call(fake)).toBe(true);
+  });
 });

--- a/src/carousel/draggable.tsx
+++ b/src/carousel/draggable.tsx
@@ -16,6 +16,7 @@ export interface Control {
   isGrabbed: () => boolean;
   setOffset: typeof Draggable.prototype.setOffset;
   toggleTransition: typeof Draggable.prototype.toggleTransition;
+  isTransitionEnabled: () => boolean;
 }
 
 export type Delta2d = { dx: number; dy: number };
@@ -107,6 +108,7 @@ export default class Draggable extends Component<DraggableProps> {
         isGrabbed: () => this.isGrabbed,
         setOffset: this.setOffset.bind(this),
         toggleTransition: this.toggleTransition.bind(this),
+        isTransitionEnabled: this.isTransitionEnabled.bind(this),
       });
   }
 
@@ -249,6 +251,14 @@ export default class Draggable extends Component<DraggableProps> {
 
       draggableEl.style.transition = active ? getTransitionStyle(duration, 'transform') : '';
     }
+  }
+
+  /**
+   * Возвращает true, если css свойство transition активно, false в противном случае.
+   * @return Активно ли css свойство transition.
+   */
+  isTransitionEnabled(): boolean {
+    return this.hasTransition;
   }
 
   /**


### PR DESCRIPTION
- `Carousel`: экспериментальная попытка заменить обработку глобального события `resize` на использование `ResizeObserver` (patch)

