### PR TITLE
#167 Panel: Обновить в соответствии с новыми гайдами

### DIFF
--- a/src/link/__stories__/link.stories.tsx
+++ b/src/link/__stories__/link.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { Link, LinkProps } from '..';
 
 export default {
@@ -10,38 +10,54 @@ export default {
   },
 };
 
-export const Primary = () => {
+export function Primary() {
   const colors: Array<Required<LinkProps>['color']> = [
     'basic-blue',
     'basic-gray87',
     'basic-gray38',
+    'basic-white',
   ];
 
-  const onClick = () => action('click')(new Date());
+  function onClick() {
+    action('click')(new Date());
+  }
+
+  const styles: Record<'root' | 'item', CSSProperties> = {
+    root: {
+      display: 'flex',
+      fontSize: 16,
+    },
+    item: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 16,
+      padding: 20,
+    },
+  };
 
   return (
-    <>
-      <div style={{ display: 'flex', fontSize: 18 }}>
-        {colors.map(color => (
-          <div key={color} style={{ marginRight: 48 }}>
-            <Link href='https://ya.ru' color={color}>
-              Ссылка
-            </Link>
+    <div style={styles.root}>
+      {colors.map(color => (
+        <div
+          key={color}
+          style={{
+            ...styles.item,
+            background: color === 'basic-white' ? '#000' : '#fff',
+          }}
+        >
+          <Link color={color} href='https://ya.ru'>
+            Ссылка
+          </Link>
 
-            <div style={{ marginBottom: 20 }} />
+          <Link color={color} pseudo onClick={onClick}>
+            Псевдо-ссылка
+          </Link>
 
-            <Link pseudo color={color} onClick={onClick}>
-              Псевдо-ссылка
-            </Link>
-
-            <div style={{ marginBottom: 20 }} />
-
-            <Link pseudo disabled color={color} onClick={onClick}>
-              Псевдо-ссылка (disabled)
-            </Link>
-          </div>
-        ))}
-      </div>
-    </>
+          <Link color={color} pseudo disabled onClick={onClick}>
+            Псевдо-ссылка (disabled)
+          </Link>
+        </div>
+      ))}
+    </div>
   );
-};
+}

--- a/src/link/index.tsx
+++ b/src/link/index.tsx
@@ -6,7 +6,7 @@ import styles from './link.module.scss';
 
 export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Цвет (название токена). */
-  color?: Extract<Token, 'basic-blue' | 'basic-gray87' | 'basic-gray38'>;
+  color?: Extract<Token, 'basic-blue' | 'basic-gray87' | 'basic-gray38' | 'basic-white'>;
 
   /** Нужно ли оборачивать содержимое комментариями no-index. */
   noIndex?: boolean;
@@ -19,6 +19,9 @@ export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>
 
   /** Идентификатор для систем автоматизированного тестирования. */
   'data-testid'?: string;
+
+  /** Нужно ли подчеркивание. */
+  underline?: boolean;
 }
 
 const cx = classnames.bind(styles);
@@ -48,6 +51,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
     pseudo,
     role,
     tabIndex,
+    underline,
     'data-testid': testId = 'anchor',
     ...restProps
   },
@@ -66,7 +70,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
       {...restProps}
       data-testid={testId}
       ref={ref}
-      className={cx('link', className, color, { disabled })}
+      className={cx('link', className, color, { disabled, underline })}
       {...getContentProps(children, noIndex)}
     />
   );

--- a/src/link/link.module.scss
+++ b/src/link/link.module.scss
@@ -9,6 +9,9 @@
   font-weight: inherit; // @todo выяснить можно ли это убрать
   cursor: default;
   border-bottom-color: transparent;
+  &.underline {
+    text-decoration: underline;
+  }
 }
 
 .link:hover {
@@ -39,5 +42,12 @@
   color: colors.$basic-gray38;
   &:hover {
     color: colors.$basic-gray54;
+  }
+}
+
+.link:not(.disabled).basic-white {
+  color: colors.$basic-white;
+  &:hover {
+    color: colors.$basic-gray4;
   }
 }

--- a/src/panel/__stories__/index.stories.tsx
+++ b/src/panel/__stories__/index.stories.tsx
@@ -1,23 +1,8 @@
-import React from 'react';
-import { Panel, PanelProps } from '..';
-import { marginBottom, marginRight } from '../../styling/sizes';
-import InfoSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/information';
-
-const variants: PanelProps[] = [
-  { color: 'basic-gray4' },
-  { color: 'additional-deep-red', contentColor: 'basic-white' },
-  { color: 'additional-teal', contentColor: 'basic-white' },
-  { color: 'additional-yellow' },
-];
-
-const longText = [
-  'Lorem ipsum dolor sit amet consectetur adipisicing elit.',
-  'Qui, dolorum? Voluptatibus ea blanditiis accusamus error',
-  'accusantium beatae eum ratione aperiam temporibus magni',
-  'non ipsum maiores officia nisi est dignissimos provident?',
-].join(' ');
-
-const markup = 'Lorem <i>ipsum</i> <b>dolor</b> sit.';
+import React, { useState } from 'react';
+import { Panel, PanelType, LINK_COLOR_BY_TYPE } from '..';
+import InformationSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/information';
+import LockSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/lock';
+import { Link } from '../../link';
 
 export default {
   title: 'common/Panel',
@@ -27,57 +12,79 @@ export default {
   },
 };
 
-export const Primary = () => (
-  <>
-    <h3>Inline</h3>
-    {variants.map((props, index) => (
-      <Panel key={index} {...props} inline className={marginRight(4) as string}>
-        Lorem ipsum
+const panelTypes: PanelType[] = ['info', 'error', 'success', 'warning'];
+
+function PanelTypeField({ onChange }: { onChange: (type: PanelType) => void }) {
+  return (
+    <div>
+      <label>
+        <span>Type </span>
+        <select onChange={e => onChange(e.target.value as any)}>
+          {panelTypes.map(item => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}
+
+export function Primary() {
+  const [type, setType] = useState<PanelType>(panelTypes[0]);
+
+  const content = (
+    <>
+      Lorem ipsum dolor sit, amet{' '}
+      <Link color={LINK_COLOR_BY_TYPE[type]} underline href='https://www.sima-land.ru'>
+        consectetur
+      </Link>{' '}
+      adipisicing elit. Dolore, aliquam. Mollitia?
+    </>
+  );
+
+  return (
+    <div style={{ width: 360, display: 'flex', gap: 20, flexDirection: 'column' }}>
+      <PanelTypeField onChange={setType} />
+
+      <Panel type={type}>{content}</Panel>
+
+      <Panel type={type} adornmentStart={<InformationSVG />}>
+        {content}
       </Panel>
-    ))}
 
-    <h3>Inline (with icon)</h3>
-    {variants.map((props, index) => (
-      <Panel key={index} {...props} inline className={marginRight(4) as string} icon={InfoSVG}>
-        Lorem ipsum
+      <Panel type={type} adornmentEnd={<LockSVG />}>
+        {content}
       </Panel>
-    ))}
 
-    <h3>Inline (with icon and markup)</h3>
-    {variants.map((props, index) => (
-      <Panel
-        key={index}
-        {...props}
-        inline
-        className={marginRight(4) as string}
-        icon={InfoSVG}
-        html={markup}
-      />
-    ))}
-
-    <h3>Block</h3>
-    {variants.map((props, index) => (
-      <Panel key={index} {...props} className={marginBottom(5) as string}>
-        {longText}
+      <Panel type={type} adornmentStart={<InformationSVG />} adornmentEnd={<LockSVG />}>
+        {content}
       </Panel>
-    ))}
+    </div>
+  );
+}
 
-    <h3>Block (with icon)</h3>
-    {variants.map((props, index) => (
-      <Panel key={index} {...props} className={marginBottom(5) as string} icon={InfoSVG}>
-        {longText}
+Primary.storyName = 'Простой пример';
+
+export function UnknownContent() {
+  const [type, setType] = useState<PanelType>(panelTypes[0]);
+
+  const markup = `
+      Lorem ipsum dolor sit, amet
+      <a href='https://www.sima-land.ru'>consectetur</a>
+      adipisicing elit. Dolore, aliquam. Mollitia?
+    `;
+
+  return (
+    <div style={{ width: 360, display: 'flex', gap: 20, flexDirection: 'column' }}>
+      <PanelTypeField onChange={setType} />
+
+      <Panel type={type} adornmentStart={<InformationSVG />}>
+        <Panel.UnknownContent markup={markup} />
       </Panel>
-    ))}
+    </div>
+  );
+}
 
-    <h3>Block (with icon and markup)</h3>
-    {variants.map((props, index) => (
-      <Panel
-        key={index}
-        {...props}
-        className={marginBottom(5) as string}
-        icon={InfoSVG}
-        html={markup}
-      />
-    ))}
-  </>
-);
+UnknownContent.storyName = 'HTML-содержимое';

--- a/src/panel/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/panel/__test__/__snapshots__/index.test.tsx.snap
@@ -1,120 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Panel /> should handle props 1`] = `
-<Panel
-  className="test-class"
-  color="basic-white"
-  contentColor="additional-red"
-  icon={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "render": [Function],
-    }
-  }
-  inline={true}
->
+<div>
   <div
-    className="panel inline bg-color__basic-white test-class"
+    class="root type-info bg-color__basic-gray4 color__basic-gray87 test-class"
     data-testid="panel"
   >
-    <ForwardRef(InformationSVG)
-      aria-hidden="true"
-      className="icon"
-      fill="#fb3a2f"
-      height={20}
-      width={16}
+    <div
+      class="adornment"
     >
       <svg
-        aria-hidden="true"
-        className="icon"
-        fill="#fb3a2f"
-        height={20}
+        height="16"
         viewBox="0 0 16 16"
-        width={16}
+        width="16"
       >
         <path
           d="M8 6.5a1 1 0 011 1v4a1 1 0 11-2 0v-4a1 1 0 011-1zM8 5.5a1 1 0 100-2 1 1 0 000 2z"
         />
         <path
-          clipRule="evenodd"
+          clip-rule="evenodd"
           d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6a6 6 0 100 12A6 6 0 008 2z"
-          fillRule="evenodd"
+          fill-rule="evenodd"
         />
       </svg>
-    </ForwardRef(InformationSVG)>
+    </div>
     <div
-      className="content color__additional-red"
+      class="main"
     >
       Hello, world!
     </div>
-  </div>
-</Panel>
-`;
-
-exports[`<Panel /> should handle props 2`] = `
-<Panel
-  className="test-class"
-  color="basic-white"
-  contentColor="additional-red"
-  html="Lorem <i>ipsum</i> <b>dolor</b> sit."
-  icon={
-    Object {
-      "$$typeof": Symbol(react.forward_ref),
-      "render": [Function],
-    }
-  }
-  inline={true}
->
-  <div
-    className="panel inline bg-color__basic-white test-class"
-    data-testid="panel"
-  >
-    <ForwardRef(InformationSVG)
-      aria-hidden="true"
-      className="icon"
-      fill="#fb3a2f"
-      height={20}
-      width={16}
+    <div
+      class="adornment"
     >
       <svg
-        aria-hidden="true"
-        className="icon"
-        fill="#fb3a2f"
-        height={20}
+        height="16"
         viewBox="0 0 16 16"
-        width={16}
+        width="16"
       >
         <path
-          d="M8 6.5a1 1 0 011 1v4a1 1 0 11-2 0v-4a1 1 0 011-1zM8 5.5a1 1 0 100-2 1 1 0 000 2z"
+          d="M9 11a1 1 0 11-2 0 1 1 0 012 0z"
         />
         <path
-          clipRule="evenodd"
-          d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6a6 6 0 100 12A6 6 0 008 2z"
-          fillRule="evenodd"
+          clip-rule="evenodd"
+          d="M4 6V4a4 4 0 118 0v2a3 3 0 013 3v4a3 3 0 01-3 3H4a3 3 0 01-3-3V9a3 3 0 013-3zm2-2a2 2 0 114 0v2H6V4zM4 8a1 1 0 00-1 1v4a1 1 0 001 1h8a1 1 0 001-1V9a1 1 0 00-1-1H4z"
+          fill-rule="evenodd"
         />
       </svg>
-    </ForwardRef(InformationSVG)>
-    <div
-      className="content color__additional-red"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Lorem <i>ipsum</i> <b>dolor</b> sit.",
-        }
-      }
-    />
+    </div>
   </div>
-</Panel>
+</div>
+`;
+
+exports[`<Panel /> should handle unknown content 1`] = `
+<div>
+  <div
+    class="root type-info bg-color__basic-gray4 color__basic-gray87 test-class"
+    data-testid="panel"
+  >
+    <div
+      class="main"
+    >
+      <div
+        class="unknown-content"
+      >
+        Lorem 
+        <i
+          data-testid="ipsum"
+        >
+          ipsum
+        </i>
+         
+        <b>
+          dolor
+        </b>
+         sit.
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`<Panel /> should renders without props 1`] = `
-<Panel>
+<div>
   <div
-    className="panel bg-color__basic-gray4"
+    class="root type-info bg-color__basic-gray4 color__basic-gray87"
     data-testid="panel"
   >
     <div
-      className="content color__basic-gray87"
+      class="main"
     />
   </div>
-</Panel>
+</div>
 `;

--- a/src/panel/__test__/index.test.tsx
+++ b/src/panel/__test__/index.test.tsx
@@ -1,39 +1,40 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { Panel } from '..';
-import InformationSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/information.js';
 import { render } from '@testing-library/react';
+import { Panel } from '..';
+import LockSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/lock';
+import InformationSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/information';
 
 describe('<Panel />', () => {
   it('should renders without props', () => {
-    const wrapper = mount(<Panel />);
+    const { container } = render(<Panel />);
 
-    expect(wrapper).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should handle props', () => {
-    const wrapper = mount(
-      <Panel
-        color='basic-white'
-        contentColor='additional-red'
-        inline
-        icon={InformationSVG}
-        className='test-class'
-        children='Hello, world!'
-      />,
+    const { container } = render(
+      <Panel adornmentStart={<InformationSVG />} adornmentEnd={<LockSVG />} className='test-class'>
+        Hello, world!
+      </Panel>,
     );
 
-    expect(wrapper).toMatchSnapshot();
-
-    wrapper.setProps({
-      children: null,
-      html: 'Lorem <i>ipsum</i> <b>dolor</b> sit.',
-    });
-
-    expect(wrapper).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
-  it('should handle "data-testid"', () => {
+  it('should handle unknown content', () => {
+    const markup = 'Lorem <i data-testid="ipsum">ipsum</i> <b>dolor</b> sit.';
+
+    const { container, queryAllByTestId } = render(
+      <Panel className='test-class'>
+        <Panel.UnknownContent markup={markup} />
+      </Panel>,
+    );
+
+    expect(container).toMatchSnapshot();
+    expect(queryAllByTestId('ipsum')).toHaveLength(1);
+  });
+
+  it('should handle "data-testid" prop', () => {
     const { container } = render(<Panel data-testid='other-panel'>Hello, world!</Panel>);
 
     expect(container.querySelectorAll('[data-testid="modal"]')).toHaveLength(0);

--- a/src/panel/panel.module.scss
+++ b/src/panel/panel.module.scss
@@ -1,29 +1,68 @@
-.panel {
+@use '../colors';
+
+.root {
   display: flex;
+  align-items: flex-start;
   padding: 16px;
   font-size: 14px;
   line-height: 20px;
   border-radius: 4px;
   overflow: hidden;
   box-sizing: border-box;
-  &.inline {
-    display: inline-flex;
+  &.type-info .unknown-content {
+    a {
+      color: colors.$basic-blue;
+      text-decoration: underline;
+      &:hover {
+        color: colors.$additional-deep-blue;
+      }
+    }
+  }
+  &.type-error .unknown-content {
+    a {
+      color: colors.$basic-white;
+      text-decoration: underline;
+      &:hover {
+        color: colors.$basic-gray4;
+      }
+    }
+  }
+  &.type-success .unknown-content {
+    a {
+      color: colors.$basic-white;
+      text-decoration: underline;
+      &:hover {
+        color: colors.$basic-gray4;
+      }
+    }
+  }
+  &.type-warning .unknown-content {
+    a {
+      color: colors.$basic-gray87;
+      text-decoration: underline;
+      &:hover {
+        color: colors.$basic-gray54;
+      }
+    }
   }
 }
 
-.icon {
+.adornment {
   flex-grow: 0;
   flex-shrink: 0;
+  svg {
+    fill: currentColor;
+  }
 }
 
-.content {
+.main {
   flex-grow: 1;
 }
 
-.icon + .content {
+.adornment + .main {
   margin-left: 16px;
 }
 
-.rotate-180 {
-  transform: rotate(180deg);
+.main + .adornment {
+  margin-left: 16px;
 }

--- a/src/side-page/__stories__/index.stories.tsx
+++ b/src/side-page/__stories__/index.stories.tsx
@@ -103,7 +103,7 @@ export const SizeM = () => {
 
         <SidePage.Body>
           <div style={styles.root}>
-            <Panel color='basic-gray4' icon={InfoSVG}>
+            <Panel type='info' adornmentStart={<InfoSVG />}>
               Обнаружили брак или не нашли часть товара в заказе? Отзыв не решит проблему. Оставьте
               претензию, и мы поможем.
             </Panel>


### PR DESCRIPTION
- `Link`: добавлен вариант цвета `basic-blue` по обновленным гайдам
- `Link`: добавлена возможность задать подчеркивание пропом `underline`

####  Major changes

- `Panel`: удален проп `inline`
- `Panel`: удален проп `color`
- `Panel`: удален проп `icon`
- `Panel`: удален проп `contentColor`
- `Panel`: удален проп `html`
- `Panel`: добавлен компонент `Panel.UnknownContent` для вывода неизвестной html-верстки
- `Panel`: добавлен проп `type` для формирования цветов по гайдам
- `Panel`: добавлены пропы `adornmentStart` и `adornmentEnd` для вывода иконок слева и справа

Closes #167 