### PR TITLE
#180 Modal: обновить в соответствии с новыми дизайн-гайдами

### DIFF
--- a/src/bottom-bar/__test__/index.test.tsx
+++ b/src/bottom-bar/__test__/index.test.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { BottomBar } from '..';
+import { BottomBar, BOTTOM_BAR_DEFAULTS, BOTTOM_BAR_HEIGHT } from '..';
 import { Clean } from '../../clean-buttons';
 
 describe('BottomBar', () => {
+  it('should handle "size" prop missing', () => {
+    const { queryAllByTestId, getByTestId } = render(
+      <BottomBar>
+        <Clean.Group>
+          <Clean.Button>Кнопка</Clean.Button>
+          <Clean.Button>Ещё кнопка</Clean.Button>
+        </Clean.Group>
+      </BottomBar>,
+    );
+
+    expect(queryAllByTestId('bottom-bar')).toHaveLength(1);
+    expect(getByTestId('bottom-bar').style.height).toBe(
+      `${BOTTOM_BAR_HEIGHT[BOTTOM_BAR_DEFAULTS.size]}px`,
+    );
+  });
+
   it('should handle "data-testid"', () => {
     const { queryAllByTestId } = render(
       <BottomBar size='s' data-testid='my-bottom-bar'>

--- a/src/bottom-bar/index.tsx
+++ b/src/bottom-bar/index.tsx
@@ -4,7 +4,7 @@ import styles from './bottom-bar.module.scss';
 import { MediumRounds } from '../styling/shapes';
 import { CleanGroupSizeContext } from '../clean-buttons/utils';
 
-type BottomBarSize = 's' | 'm' | 'l';
+export type BottomBarSize = 's' | 'm' | 'l';
 
 export interface BottomBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'size'> {
   /** Размер (высота). */

--- a/src/breakpoints.scss
+++ b/src/breakpoints.scss
@@ -22,7 +22,7 @@ $map: (
 
 @mixin down($breakpoint) {
   @if map-has-key($map, $breakpoint) {
-    @media (max-width: map-get($map, $breakpoint) - 1px) {
+    @media (max-width: (map-get($map, $breakpoint) - 1px)) {
       @content;
     }
   } @else {

--- a/src/layout/__stories__/desktop.stories.tsx
+++ b/src/layout/__stories__/desktop.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DesktopLayout } from '..';
 
 export default {
-  title: 'Layouts/DesktopLayout',
+  title: 'deprecated/DesktopLayout',
   component: DesktopLayout,
   parameters: {
     layout: 'fullscreen',

--- a/src/layout/__stories__/index.stories.tsx
+++ b/src/layout/__stories__/index.stories.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Layout } from '..';
+
+export default {
+  title: 'common/Layout',
+  component: Layout,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+const SomeContent = () => (
+  <div style={{ background: 'rgb(207, 232, 252)' }}>
+    <h2>Контент ограниченный layout`ом</h2>
+    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Soluta, nostrum!</p>
+  </div>
+);
+
+export function Primary() {
+  return (
+    <>
+      <Layout>
+        <h2>Простой пример</h2>
+      </Layout>
+
+      <Layout>
+        <SomeContent />
+      </Layout>
+    </>
+  );
+}
+
+Primary.storyName = 'Простой пример';
+
+export function DisableOnBreakpoint() {
+  return (
+    <>
+      <Layout>
+        <h2>Отключение на определенных разрешениях</h2>
+        <p>Необходимо изменить ширину окна для эффекта</p>
+      </Layout>
+
+      <Layout disabledOn={['mxs']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['ms']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['mm']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['ml']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['xs']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['s']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['m']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['l']}>
+        <SomeContent />
+      </Layout>
+      <Layout disabledOn={['xl']}>
+        <SomeContent />
+      </Layout>
+    </>
+  );
+}
+
+DisableOnBreakpoint.storyName = "Отключение не определённом breakpoint'е";

--- a/src/layout/__stories__/mobile.stories.tsx
+++ b/src/layout/__stories__/mobile.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MobileLayout } from '..';
 
 export default {
-  title: 'Layouts/MobileLayout',
+  title: 'deprecated/MobileLayout',
   component: MobileLayout,
   parameters: {
     layout: 'fullscreen',

--- a/src/layout/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/layout/__test__/__snapshots__/index.test.tsx.snap
@@ -1,125 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Layouts should handle "disabledOn" prop 1`] = `
-<DesktopLayout
-  disabledOn={
-    Array [
-      "xl",
-      "xs",
-    ]
-  }
->
+exports[`Layout should handle "disabledOn" prop 1`] = `
+<div>
   <div
-    className="layout desktop disabled-xl disabled-xs"
+    class="layout disabled-xl disabled-xs"
   >
     Hello, world!
   </div>
-</DesktopLayout>
+</div>
 `;
 
-exports[`Layouts should handle "disabledOn" prop 2`] = `
-<MobileLayout
-  disabledOn={
-    Array [
-      "xl",
-      "xs",
-    ]
-  }
->
+exports[`Layout should handle "element" prop 1`] = `
+<div>
   <div
-    className="layout mobile disabled-xl disabled-xs"
+    class="layout test-class "
+    element="main"
+    style="height: 128px;"
   >
     Hello, world!
   </div>
-</MobileLayout>
+</div>
 `;
 
-exports[`Layouts should handle "element" prop 1`] = `
-<DesktopLayout
-  className="test-class"
-  element="main"
-  style={
-    Object {
-      "height": 128,
-    }
-  }
->
+exports[`Layout should renders correctly 1`] = `
+<div>
+  <div
+    class="layout test-class "
+    style="height: 128px;"
+  >
+    Hello, world!
+  </div>
+</div>
+`;
+
+exports[`Layouts (legacy) should handle "disabledOn" prop 1`] = `
+<div>
+  <div
+    class="layout desktop disabled-xl disabled-xs"
+  >
+    Hello, world!
+  </div>
+</div>
+`;
+
+exports[`Layouts (legacy) should handle "disabledOn" prop 2`] = `
+<div>
+  <div
+    class="layout mobile disabled-xl disabled-xs"
+  >
+    Hello, world!
+  </div>
+</div>
+`;
+
+exports[`Layouts (legacy) should handle "element" prop 1`] = `
+<div>
   <main
-    className="layout desktop test-class "
-    style={
-      Object {
-        "height": 128,
-      }
-    }
+    class="layout desktop test-class "
+    style="height: 128px;"
   >
     Hello, world!
   </main>
-</DesktopLayout>
+</div>
 `;
 
-exports[`Layouts should handle "element" prop 2`] = `
-<MobileLayout
-  className="test-class"
-  element="main"
-  style={
-    Object {
-      "height": 128,
-    }
-  }
->
+exports[`Layouts (legacy) should handle "element" prop 2`] = `
+<div>
   <main
-    className="layout mobile test-class "
-    style={
-      Object {
-        "height": 128,
-      }
-    }
+    class="layout mobile test-class "
+    style="height: 128px;"
   >
     Hello, world!
   </main>
-</MobileLayout>
+</div>
 `;
 
-exports[`Layouts should renders correctly 1`] = `
-<DesktopLayout
-  className="test-class"
-  style={
-    Object {
-      "height": 128,
-    }
-  }
->
+exports[`Layouts (legacy) should renders correctly 1`] = `
+<div>
   <div
-    className="layout desktop test-class "
-    style={
-      Object {
-        "height": 128,
-      }
-    }
+    class="layout desktop test-class "
+    style="height: 128px;"
   >
     Hello, world!
   </div>
-</DesktopLayout>
+</div>
 `;
 
-exports[`Layouts should renders correctly 2`] = `
-<MobileLayout
-  className="test-class"
-  style={
-    Object {
-      "height": 128,
-    }
-  }
->
+exports[`Layouts (legacy) should renders correctly 2`] = `
+<div>
   <div
-    className="layout mobile test-class "
-    style={
-      Object {
-        "height": 128,
-      }
-    }
+    class="layout mobile test-class "
+    style="height: 128px;"
   >
     Hello, world!
   </div>
-</MobileLayout>
+</div>
 `;

--- a/src/layout/__test__/index.test.tsx
+++ b/src/layout/__test__/index.test.tsx
@@ -1,33 +1,63 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { DesktopLayout, MobileLayout } from '..';
+import { render } from '@testing-library/react';
+import { Layout, DesktopLayout, MobileLayout } from '..';
 
-describe('Layouts', () => {
-  [DesktopLayout, MobileLayout].forEach(Layout => {
+describe('Layout', () => {
+  it('should renders correctly', () => {
+    const { container } = render(
+      <Layout className='test-class' style={{ height: 128 }}>
+        Hello, world!
+      </Layout>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should handle "element" prop', () => {
+    const { container } = render(
+      <Layout element='main' className='test-class' style={{ height: 128 }}>
+        Hello, world!
+      </Layout>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should handle "disabledOn" prop', () => {
+    const { container } = render(<Layout disabledOn={['xl', 'xs']}>Hello, world!</Layout>);
+
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe('Layouts (legacy)', () => {
+  [DesktopLayout, MobileLayout].forEach(LayoutComponent => {
     it('should renders correctly', () => {
-      const wrapper = mount(
-        <Layout className='test-class' style={{ height: 128 }}>
+      const { container } = render(
+        <LayoutComponent className='test-class' style={{ height: 128 }}>
           Hello, world!
-        </Layout>,
+        </LayoutComponent>,
       );
 
-      expect(wrapper).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     it('should handle "element" prop', () => {
-      const wrapper = mount(
-        <Layout element='main' className='test-class' style={{ height: 128 }}>
+      const { container } = render(
+        <LayoutComponent element='main' className='test-class' style={{ height: 128 }}>
           Hello, world!
-        </Layout>,
+        </LayoutComponent>,
       );
 
-      expect(wrapper).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
 
     it('should handle "disabledOn" prop', () => {
-      const wrapper = mount(<Layout disabledOn={['xl', 'xs']}>Hello, world!</Layout>);
+      const { container } = render(
+        <LayoutComponent disabledOn={['xl', 'xs']}>Hello, world!</LayoutComponent>,
+      );
 
-      expect(wrapper).toMatchSnapshot();
+      expect(container).toMatchSnapshot();
     });
   });
 });

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -1,0 +1,6 @@
+import { Breakpoint, LayoutProps } from './types';
+import { Layout } from './layout';
+import { MobileLayout, DesktopLayout } from './legacy';
+
+export type { Breakpoint, LayoutProps };
+export { Layout, MobileLayout, DesktopLayout };

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react';
+import { LayoutProps } from './types';
+import classNames from 'classnames/bind';
+import styles from './layout.module.scss';
+
+const cx = classNames.bind(styles);
+
+export const Layout = forwardRef<HTMLElement, LayoutProps>(function Layout(
+  { className, disabledOn = [], ...restProps },
+  ref,
+) {
+  return (
+    <div
+      {...(restProps as any)}
+      ref={ref}
+      className={cx(
+        'layout',
+        className,
+        disabledOn.map(key => `disabled-${key}`),
+      )}
+    />
+  );
+});

--- a/src/layout/legacy.module.scss
+++ b/src/layout/legacy.module.scss
@@ -15,10 +15,11 @@
       }
     }
   }
-  @include breakpoints.up('mxs') {
-    --l-width: calc(100vw - (var(--l-gutter) * 2));
-    --l-gutter: 16px;
-  }
+}
+
+.mobile {
+  --l-gutter: 16px;
+  --l-width: calc(100vw - (2 * var(--l-gutter)));
   @include breakpoints.up('mm') {
     --l-width: 656px;
     --l-gutter: auto;
@@ -28,9 +29,15 @@
     --l-gutter: auto;
   }
   @include breakpoints.up('xs') {
-    --l-width: calc(100vw - (var(--l-gutter) * 2));
-    --l-gutter: 64px;
+    --l-width: 792px;
+    --l-gutter: auto;
   }
+}
+
+.desktop {
+  min-width: 896px;
+  --l-gutter: 64px;
+  --l-width: calc(100vw - (2 * var(--l-gutter)));
   @include breakpoints.up('l') {
     --l-width: 1472px;
     --l-gutter: auto;

--- a/src/layout/legacy.tsx
+++ b/src/layout/legacy.tsx
@@ -1,16 +1,7 @@
 import React, { forwardRef } from 'react';
+import { LayoutProps } from './types';
 import classnames from 'classnames/bind';
-import classes from './layout.module.scss';
-
-type Breakpoint = 'mxs' | 'ms' | 'mm' | 'ml' | 'xs' | 's' | 'm' | 'l' | 'xl';
-
-export interface LayoutProps extends React.HTMLAttributes<HTMLElement> {
-  /** Тэг. */
-  element?: string;
-
-  /** Список точек остановки на которых необходимо отключить ограничение ширины. */
-  disabledOn?: Array<Breakpoint>;
-}
+import classes from './legacy.module.scss';
 
 const cx = classnames.bind(classes);
 

--- a/src/layout/types.ts
+++ b/src/layout/types.ts
@@ -1,0 +1,9 @@
+export type Breakpoint = 'mxs' | 'ms' | 'mm' | 'ml' | 'xs' | 's' | 'm' | 'l' | 'xl';
+
+export interface LayoutProps extends React.HTMLAttributes<HTMLElement> {
+  /** Тэг. */
+  element?: string;
+
+  /** Список точек остановки на которых необходимо отключить ограничение ширины. */
+  disabledOn?: Array<Breakpoint>;
+}

--- a/src/modal/__stories__/index.stories.tsx
+++ b/src/modal/__stories__/index.stories.tsx
@@ -1,28 +1,53 @@
 import React, { useState } from 'react';
-import { Story } from '@storybook/react';
 import { Modal, ModalProps } from '..';
 import { Button } from '../../button';
 import { Clean } from '../../clean-buttons';
-import { DesktopLayout } from '../../layout';
-import { marginRight } from '../../styling/sizes';
+import { Layout } from '../../layout';
 import { Box } from '../../box';
 import { action } from '@storybook/addon-actions';
 import { ArrowButton } from '../../arrow-button';
 
-const Template: Story<ModalProps> = props => {
+export default {
+  title: 'common/Modal',
+  component: Modal,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+function LotOfText({ lines = 20 }: { lines: number }) {
+  return (
+    <>
+      {[...Array(Math.max(lines, 0)).keys()].map(index => (
+        <p key={index}>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Odio consectetur ab ratione
+          magni laboriosam nemo, incidunt error aliquam deleniti cum?
+        </p>
+      ))}
+    </>
+  );
+}
+
+const SizeTemplate = (props: ModalProps) => {
   const [opened, toggleModal] = useState<boolean>(true);
 
   return (
     <>
-      <Button onClick={() => toggleModal(true)}>Показать окно</Button>
+      <LotOfText lines={5} />
+
+      <Button size='s' onClick={() => toggleModal(true)}>
+        Показать окно
+      </Button>
+
+      <LotOfText lines={100} />
 
       {opened && (
-        <Modal onClose={() => toggleModal(false)} {...props} withScrollDisable>
-          <Modal.Header divided title='Модальное окно' />
+        <Modal {...props} withScrollDisable onClose={() => toggleModal(false)}>
+          <Modal.Header divided title='Модальное окно' onClose={() => toggleModal(false)} />
           <Modal.Body>
-            <div style={{ padding: 24 }}>Содержимое модального окна</div>
+            <Box padding={6}>Содержимое модального окна</Box>
           </Modal.Body>
-          <Modal.Footer divided size='s'>
+          <Modal.Footer divided>
             <Clean.Group>
               <Clean.Button>Кнопка</Clean.Button>
               <Clean.Button>Ещё кнопка</Clean.Button>
@@ -30,160 +55,185 @@ const Template: Story<ModalProps> = props => {
           </Modal.Footer>
         </Modal>
       )}
-
-      {[...Array(100).keys()].map(index => (
-        <p key={index}>
-          Очень много контента для проверки блокировки прокрутки под окном [{index}]
-        </p>
-      ))}
     </>
   );
 };
 
-export default {
-  title: 'desktop/Modal',
-  component: Modal,
-  parameters: {
-    layout: 'padded',
-  },
-};
-
-export const SizeS = Template.bind(null, {
+export const SizeS = SizeTemplate.bind(null, {
   size: 's',
   height: 300,
-});
+}) as any;
 
-export const SizeM = Template.bind(null, {
+SizeS.storyName = 'Размер S';
+
+export const SizeM = SizeTemplate.bind(null, {
+  size: 'm',
   height: 400,
-});
+}) as any;
 
-export const SizeL = Template.bind(null, {
+SizeM.storyName = 'Размер M';
+
+export const SizeL = SizeTemplate.bind(null, {
   size: 'l',
   height: 500,
-});
+}) as any;
 
-export const SizeXL = Template.bind(null, {
+SizeL.storyName = 'Размер L';
+
+export const SizeXL = SizeTemplate.bind(null, {
   size: 'xl',
   height: 600,
-});
+}) as any;
 
-export const Fullscreen: Story = () => (
-  <Modal size='fullscreen'>
-    <Modal.Header divided title='Полноэкранное модальное окно' />
-    <Modal.Body>
-      <div style={{ height: '100%', background: '#eee' }}>
-        <DesktopLayout>
-          <Box padding={6}>Содержимое модального окна</Box>
-        </DesktopLayout>
-      </div>
-    </Modal.Body>
-    <Modal.Footer divided>
-      <DesktopLayout>
-        <Box marginY={3} display='flex' justifyContent='end'>
-          <Button viewType='secondary' className={marginRight(3)}>
-            Кнопка
-          </Button>
-          <Button>Кнопка</Button>
-        </Box>
-      </DesktopLayout>
-    </Modal.Footer>
-  </Modal>
-);
+SizeXL.storyName = 'Размер XL';
 
-export const WithoutBars: Story = () => (
-  <Modal size='s' height={320}>
-    <Modal.Body>
-      <div style={{ padding: 24 }}>Содержимое модального окна</div>
-    </Modal.Body>
-  </Modal>
-);
+export function Fullscreen() {
+  return (
+    <>
+      <Modal size='fullscreen'>
+        <Modal.Header divided title='Полноэкранное модальное окно' />
+        <Modal.Body>
+          <div
+            style={{
+              height: 'calc(100vh - var(--modal-header-height) - var(--modal-footer-height))',
+              background: '#eee',
+            }}
+          >
+            <Layout>
+              <Box padding={6}>Содержимое модального окна</Box>
+            </Layout>
+          </div>
+        </Modal.Body>
+        <Modal.Footer divided>
+          <Layout
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              height: '100%',
+            }}
+          >
+            <Button viewType='secondary' style={{ marginRight: 12 }}>
+              Кнопка
+            </Button>
+            <Button viewType='primary'>Кнопка</Button>
+          </Layout>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
 
-export const DynamicHeight: Story<ModalProps> = () => {
+Fullscreen.storyName = 'На весь экран';
+
+export function WithoutBars() {
+  return (
+    <Modal size='s' height={320}>
+      <Modal.Body>
+        <div style={{ padding: 24 }}>Содержимое модального окна</div>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+WithoutBars.storyName = 'Без шапки и подвала';
+
+export function TestDynamicHeight() {
   const [count, setCount] = useState<number>(1);
+
+  function increment() {
+    setCount(count + 1);
+  }
+
+  function decrement() {
+    setCount(count - 1);
+  }
+
+  function onFullScroll() {
+    action('FULLY SCROLLED')();
+  }
 
   return (
     <Modal>
       <Modal.Header divided title='Проверка высоты' />
-      <Modal.Body onFullScroll={() => action('FULLY SCROLLED')()}>
-        <div style={{ padding: '32px' }}>
-          {[...Array(count).keys()].map(index => (
-            <div
-              key={index}
-              style={{ padding: 24, marginTop: index ? '16px' : 0, background: '#ddd' }}
-              onClick={() => setCount(count + 1)}
-            >
-              Нажми на меня чтобы добавить немножко контента
-            </div>
-          ))}
+      <Modal.Body onFullScroll={onFullScroll}>
+        <div style={{ padding: '32px' }} onClick={increment}>
+          <LotOfText lines={count} />
         </div>
       </Modal.Body>
-      <Modal.Footer divided size='s'>
+      <Modal.Footer divided>
         <Clean.Group>
-          <Clean.Button>Кнопка</Clean.Button>
-          <Clean.Button>Ещё кнопка</Clean.Button>
+          <Clean.Button onClick={decrement}>Убрать</Clean.Button>
+          <Clean.Button onClick={increment}>Добавить</Clean.Button>
         </Clean.Group>
       </Modal.Footer>
     </Modal>
   );
-};
+}
 
-export const WithScroll: Story = () => (
-  <Modal size='s' height={360}>
-    <Modal.Header divided title='Проверка прокрутки' />
-    <Modal.Body>
-      <div style={{ padding: 24 }}>
-        {Array(50)
-          .fill(0)
-          .map((a, i) => (
-            <p key={i}>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Sit, sed ex odio
-              voluptatibus laborum vero.
-            </p>
-          ))}
-      </div>
-    </Modal.Body>
-  </Modal>
-);
+TestDynamicHeight.storyName = 'Тест: динамическая высота';
 
-export const WithOverlapContent: Story = () => (
-  <Modal size='l'>
-    <Modal.Header divided title='Со стрелочками рядом с окном' />
-    <Modal.Body>
-      <div style={{ padding: 24 }}>
-        {Array(50)
-          .fill(0)
-          .map((a, i) => (
-            <p key={i}>
-              Lorem ipsum dolor sit amet consectetur, adipisicing elit. Sit, sed ex odio
-              voluptatibus laborum vero.
-            </p>
-          ))}
-      </div>
-    </Modal.Body>
-    <Modal.Overlap>
-      <ArrowButton
-        style={{
-          position: 'absolute',
-          top: '50%',
-          transform: 'translateY(-50%)',
-          right: 'calc(100% + 24px)',
-        }}
-        direction='left'
-        onClick={action('Modal arrow click, prev')}
-      />
-      <ArrowButton
-        style={{
-          position: 'absolute',
-          top: '50%',
-          transform: 'translateY(-50%)',
-          left: 'calc(100% + 24px)',
-        }}
-        direction='right'
-        onClick={action('Modal arrow click, next')}
-      />
-    </Modal.Overlap>
-  </Modal>
-);
+export function WithScroll() {
+  return (
+    <Modal size='s' height={360}>
+      <Modal.Header divided title='Проверка прокрутки' />
+      <Modal.Body>
+        <div style={{ padding: 24 }}>
+          <LotOfText lines={100} />
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+WithScroll.storyName = 'Тест: внутренняя прокрутка';
+
+export function WithOverlapContent() {
+  const [count, setCount] = useState(99);
+
+  return (
+    <Modal size='m'>
+      <Modal.Header divided title='Со стрелочками рядом с окном' />
+      <Modal.Body>
+        <div
+          style={{
+            height: 360,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: '64px',
+          }}
+        >
+          {count}
+        </div>
+      </Modal.Body>
+      <Modal.Overlap>
+        <ArrowButton
+          style={{
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            right: 'calc(100% + 24px)',
+          }}
+          direction='left'
+          onClick={() => setCount(count - 1)}
+        />
+        <ArrowButton
+          style={{
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            left: 'calc(100% + 24px)',
+          }}
+          direction='right'
+          onClick={() => setCount(count + 1)}
+        />
+      </Modal.Overlap>
+    </Modal>
+  );
+}
+
+WithOverlapContent.storyName = 'Контент рядом с окном';
 
 interface StepProps {
   setStep: React.Dispatch<React.SetStateAction<number>>;
@@ -196,7 +246,7 @@ function FirstStep({ setStep }: StepProps) {
       <Modal.Body>
         <div style={{ height: '300px' }}></div>
       </Modal.Body>
-      <Modal.Footer divided size='s'>
+      <Modal.Footer divided>
         <Clean.Group>
           <Clean.Button onClick={() => setStep(s => s + 1)}>Дальше</Clean.Button>
         </Clean.Group>
@@ -212,7 +262,7 @@ function SecondStep({ setStep }: StepProps) {
       <Modal.Body>
         <div style={{ height: '300px' }}></div>
       </Modal.Body>
-      <Modal.Footer divided size='s'>
+      <Modal.Footer divided>
         <Clean.Group>
           <Clean.Button onClick={() => setStep(s => s - 1)}>Назад</Clean.Button>
           <Clean.Button onClick={() => setStep(s => s + 1)}>Далее</Clean.Button>
@@ -230,7 +280,7 @@ function ThirdStep({ setStep }: StepProps) {
         <div style={{ height: '300px' }}></div>
       </Modal.Body>
 
-      <Modal.Footer divided size='s'>
+      <Modal.Footer divided>
         <Clean.Group>
           <Clean.Button onClick={() => setStep(-1)}>Готово</Clean.Button>
         </Clean.Group>
@@ -239,7 +289,7 @@ function ThirdStep({ setStep }: StepProps) {
   );
 }
 
-export function Toggle() {
+export function TestToggle() {
   const [step, setStep] = useState<number>(-1);
 
   return (
@@ -260,4 +310,4 @@ export function Toggle() {
   );
 }
 
-Toggle.storyName = 'Блокировка прокрутки при переключении окон';
+TestToggle.storyName = 'Блокировка прокрутки при переключении окон';

--- a/src/modal/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/modal/__test__/__snapshots__/index.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`<Modal /> renders correct without close button and customClasses 1`] = 
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -30,7 +30,7 @@ exports[`<Modal /> should handle "height" prop 1`] = `
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--modal-height: 480px; --header-height: 0px; --footer-height: 16px;"
+      style="--modal-height: 480px; --modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -50,7 +50,7 @@ exports[`<Modal /> should handle extended props 1`] = `
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--header-height: 64px; --footer-height: 72px;"
+      style="--modal-header-height: 64px; --modal-footer-height: 72px;"
     >
       <div
         class="root size-m header"
@@ -192,7 +192,7 @@ exports[`<Modal /> should handle extended props 1`] = `
         />
       </div>
       <div
-        class="root rounds-md__b"
+        class="root rounds-md__b footer"
         data-testid="bottom-bar"
         style="height: 72px;"
       >
@@ -215,7 +215,7 @@ exports[`<Modal /> should render TopBar with back button 1`] = `
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--header-height: 64px; --footer-height: 16px;"
+      style="--modal-header-height: 64px; --modal-footer-height: 16px;"
     >
       <div
         class="root size-m header no-subtitle"
@@ -286,7 +286,7 @@ exports[`<Modal /> should render different sizes properly 1`] = `
     <div
       class="modal size-s shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -306,7 +306,7 @@ exports[`<Modal /> should render different sizes properly 2`] = `
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -326,7 +326,7 @@ exports[`<Modal /> should render different sizes properly 3`] = `
     <div
       class="modal size-l shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -346,7 +346,7 @@ exports[`<Modal /> should render different sizes properly 4`] = `
     <div
       class="modal size-xl shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="footer-stub"
@@ -366,7 +366,7 @@ exports[`<Modal /> should render different sizes properly 5`] = `
     <div
       class="modal size-fullscreen"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 0px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     />
   </div>
 </div>
@@ -382,7 +382,7 @@ exports[`<Modal /> should render overlap content 1`] = `
     <div
       class="modal size-m shadow-z4"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 16px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 16px;"
     >
       <div
         class="os-host os-host-foreign os-theme-dark os-host-resize-disabled os-host-scrollbar-horizontal-hidden os-host-scrollbar-vertical-hidden custom-scrollbar body os-host-flexbox"
@@ -527,10 +527,10 @@ exports[`<Modal /> should renders with fullscreen size and footer 1`] = `
     <div
       class="modal size-fullscreen"
       data-testid="modal"
-      style="--header-height: 0px; --footer-height: 72px;"
+      style="--modal-header-height: 0px; --modal-footer-height: 80px;"
     >
       <div
-        class="root rounds-md__b"
+        class="root rounds-md__b footer"
         data-testid="bottom-bar"
         style="height: 80px;"
       >

--- a/src/modal/modal.module.scss
+++ b/src/modal/modal.module.scss
@@ -1,4 +1,5 @@
 @use '../colors';
+@use '../breakpoints';
 
 $max-height: 696px;
 
@@ -23,21 +24,33 @@ $max-height: 696px;
   margin: auto;
   flex-shrink: 0;
   z-index: 1;
-  max-height: $max-height;
   height: var(--modal-height, auto);
-  &.size-s {
-    width: 480px;
+  max-height: min(#{$max-height}, calc(100vh - 32px));
+  min-height: 232px;
+  @include breakpoints.up('xs') {
+    &.size-s {
+      width: 480px;
+    }
+    &.size-m {
+      width: 640px;
+    }
+    &.size-l {
+      width: 768px;
+    }
+    &.size-xl {
+      width: 960px;
+    }
+    &.size-fullscreen {
+      width: 100%;
+      height: 100%;
+      max-height: 100%;
+      border-radius: 0;
+      .body {
+        max-height: none;
+      }
+    }
   }
-  &.size-m {
-    width: 640px;
-  }
-  &.size-l {
-    width: 768px;
-  }
-  &.size-xl {
-    width: 960px;
-  }
-  &.size-fullscreen {
+  @include breakpoints.down('xs') {
     width: 100%;
     height: 100%;
     max-height: 100%;
@@ -68,7 +81,7 @@ $max-height: 696px;
 .body {
   flex-grow: 1;
   max-height: calc(
-    var(--modal-height, #{$max-height}) - var(--header-height) - var(--footer-height)
+    var(--modal-height, #{$max-height}) - var(--modal-header-height) - var(--modal-footer-height)
   );
 }
 
@@ -80,6 +93,7 @@ $max-height: 696px;
 }
 
 .footer {
+  flex-shrink: 0;
   border-radius: 0 0 8px 8px;
   overflow: hidden;
 }

--- a/src/modal/slots.tsx
+++ b/src/modal/slots.tsx
@@ -1,61 +1,72 @@
-import React, { useRef } from 'react';
+import React, { ReactNode, useContext, useRef } from 'react';
 import { TopBar, TopBarProps } from '../top-bar';
 import CrossSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/cross';
 import ArrowLeftSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/arrow-left';
 import { BottomBar, BottomBarProps } from '../bottom-bar';
 import { CustomScrollbar } from '../_internal/custom-scrollbar';
-import styles from './modal.module.scss';
 import { ViewportContext } from '../context/viewport';
 import { BSL_IGNORE_ATTR } from '../constants';
+import { ModalContext } from './utils';
+import classNames from 'classnames/bind';
+import styles from './modal.module.scss';
 
-export interface ModalHeaderProps extends TopBarProps {
+const cx = classNames.bind(styles);
+
+export interface ModalHeaderProps extends Omit<TopBarProps, 'size'> {
   onBack?: () => void;
   onClose?: () => void;
 }
+
+export type ModalFooterProps = Omit<BottomBarProps, 'size'>;
 
 /**
  * Шапка окна.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalHeader = ({ onBack, onClose, ...topBarProps }: ModalHeaderProps) => (
-  <TopBar
-    {...topBarProps}
-    buttons={{
-      ...topBarProps.buttons,
-      ...(onBack && {
-        start: {
-          'data-testid': 'modal:back',
-          onClick: onBack,
-          icon: <ArrowLeftSVG />,
-        },
-      }),
-      ...(onClose && {
-        end: {
-          'data-testid': 'modal:close',
-          onClick: onClose,
-          icon: <CrossSVG />,
-        },
-      }),
-    }}
-    className={styles.header}
-  />
-);
+export function ModalHeader({ className, onBack, onClose, buttons, ...rest }: ModalHeaderProps) {
+  const { topBarSize } = useContext(ModalContext);
+
+  return (
+    <TopBar
+      {...rest}
+      size={topBarSize}
+      buttons={{
+        ...buttons,
+        ...(onBack && {
+          start: {
+            'data-testid': 'modal:back',
+            onClick: onBack,
+            icon: <ArrowLeftSVG />,
+          },
+        }),
+        ...(onClose && {
+          end: {
+            'data-testid': 'modal:close',
+            onClick: onClose,
+            icon: <CrossSVG />,
+          },
+        }),
+      }}
+      className={cx('header', className)}
+    />
+  );
+}
 
 /**
  * Основной контент окна.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalBody = ({
+export function ModalBody({
   children,
   onFullScroll,
   fullScrollThreshold,
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
   fullScrollThreshold?: number;
   onFullScroll?: () => void;
-}) => {
+}) {
   const ref = useRef<HTMLDivElement>(null);
 
   return (
@@ -73,18 +84,24 @@ export const ModalBody = ({
       </ViewportContext.Provider>
     </CustomScrollbar>
   );
-};
+}
 
 /**
  * Футер окна.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalFooter = (props: BottomBarProps) => <BottomBar {...props} />;
+export function ModalFooter({ className, ...rest }: ModalFooterProps) {
+  const { bottomBarSize } = useContext(ModalContext);
+
+  return <BottomBar {...rest} size={bottomBarSize} className={cx('footer', className)} />;
+}
 
 /**
  * Контент который будет выводится поверх окна с абсолютным позиционированием.
  * @param props Свойства.
  * @return Элемент.
  */
-export const ModalOverlap: React.FC = ({ children }) => <>{children}</>;
+export function ModalOverlap({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/modal/utils.ts
+++ b/src/modal/utils.ts
@@ -1,5 +1,7 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, createContext } from 'react';
+import { BottomBarSize } from '../bottom-bar';
 import { useIdentityRef } from '../hooks/identity';
+import { TopBarSize } from '../top-bar';
 
 /**
  * Вызывает callback только если клик был начат и закончен по одному и тому же элементу.
@@ -28,3 +30,8 @@ export const useCloseHandler = (callback?: () => void) => {
 
   return { onMouseUp, onMouseDown };
 };
+
+export const ModalContext = createContext<{
+  topBarSize?: TopBarSize;
+  bottomBarSize?: BottomBarSize;
+}>({});


### PR DESCRIPTION
- `Modal`: компонент обновлен в соответствии с новыми дизайн-гайдами (major)
- `BottomBar`: BottomBarSize теперь экспортируется (minor)
- `Layout`: добавлен новый единый компонент Layout для всех разрешений (minor)
- `useBreakpoint`: хук теперь не требует наличия BreakpointProvider в дереве (minor)

Closes #180