### PR TITLE
Шаг 2 #110 CheckboxField: доработать в соответствии с новыми дизайн-гайдами

### DIFF
--- a/src/_internal/checkbox/index.ts
+++ b/src/_internal/checkbox/index.ts
@@ -1,6 +1,0 @@
-import { InputHTMLAttributes } from 'react';
-
-export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
-  /** Идентификатор для систем автоматизированного тестирования. */
-  'data-testid'?: string;
-}

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -1,11 +1,11 @@
 import React, { forwardRef } from 'react';
+import { CheckboxInputProps } from '../types';
 import classnames from 'classnames/bind';
-import classes from './checkbox.module.scss';
-import { CheckboxProps } from '../_internal/checkbox';
+import styles from './checkbox.module.scss';
 
-export type { CheckboxProps };
+export type CheckboxProps = CheckboxInputProps;
 
-const cx = classnames.bind(classes);
+const cx = classnames.bind(styles);
 
 /**
  * Компонент стилизованного переключателя (input[type=checkbox]).

--- a/src/radio-button/index.tsx
+++ b/src/radio-button/index.tsx
@@ -1,13 +1,14 @@
 import React, { InputHTMLAttributes } from 'react';
-import styles from './radio-button.module.scss';
+import { FieldProps, WithTestId } from '../types';
 import classNames from 'classnames/bind';
+import styles from './radio-button.module.scss';
 
 const cx = classNames.bind(styles);
 
-export interface RadioButtonProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
-  /** Идентификатор для систем автоматизированного тестирования. */
-  'data-testid'?: string;
-}
+export interface RadioButtonProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>,
+    FieldProps,
+    WithTestId {}
 
 /**
  * Радио-кнопка.

--- a/src/switcher-row/__stories__/index.stories.tsx
+++ b/src/switcher-row/__stories__/index.stories.tsx
@@ -84,6 +84,7 @@ export function DifferentStates() {
 
   const fieldProps = {
     id: 'example-field',
+    failed: state.includes('failed'),
     disabled: state.includes('disabled'),
   };
 
@@ -126,7 +127,6 @@ export function DifferentStates() {
       <SwitcherRow
         fieldPosition={fieldPosition}
         textAlign={textAlign}
-        failed={state.includes('failed')}
         style={{
           maxWidth: '400px',
           margin: 'auto',

--- a/src/switcher-row/index.tsx
+++ b/src/switcher-row/index.tsx
@@ -13,9 +13,6 @@ export interface SwitcherRowProps {
   /** Направление текста. */
   textAlign?: 'left' | 'right';
 
-  /** Состояние с ошибками валидации. */
-  failed?: boolean;
-
   /** Стили корневого элемента. */
   style?: CSSProperties;
 
@@ -40,7 +37,6 @@ export function SwitcherRow({
   children,
   className,
   style,
-  failed,
   textAlign,
   fieldPosition = 'start',
   'data-testid': testId = 'switcher-row',
@@ -54,6 +50,7 @@ export function SwitcherRow({
   });
 
   const input = toggle ?? checkbox ?? radio;
+  const failed = input?.props.failed;
   const disabled = input?.props.disabled;
   const fieldId = input?.props.id;
   const fieldColumn = input && <div className={cx('col', 'field-col')}>{input}</div>;

--- a/src/toggle/index.tsx
+++ b/src/toggle/index.tsx
@@ -1,16 +1,16 @@
 import React, { forwardRef } from 'react';
+import { CheckboxInputProps } from '../types';
 import classnames from 'classnames/bind';
 import styles from './toggle.module.scss';
-import { CheckboxProps } from '../_internal/checkbox';
 
-export type ToggleProps = CheckboxProps;
+export type ToggleProps = CheckboxInputProps;
 
 const cx = classnames.bind(styles);
 
 /**
  * Компонент стилизованного переключателя (input[type=checkbox]).
  */
-export const Toggle = forwardRef<HTMLInputElement, CheckboxProps>(
+export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   (
     {
       className,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,19 @@
+import type { InputHTMLAttributes } from 'react';
+
+/** Свойства компонента для маркировки атрибутом "data-testid". */
+export interface WithTestId {
+  /** Идентификатор для систем автоматизированного тестирования. */
+  'data-testid'?: string;
+}
+
+/** Свойства любого поля ввода. */
+export interface FieldProps {
+  /** Состояние с ошибками валидации. */
+  failed?: boolean;
+}
+
+/** Свойства компонента поля переключателя (input[type="checkbox"]). */
+export interface CheckboxInputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    FieldProps,
+    WithTestId {}


### PR DESCRIPTION
- internal: тип CheckboxProps перенесен в src/types.ts и переименован в CheckboxInputProps
- types: добавлены типы WithTestId, FieldProps
- checkbox: задействованы новые типы
- toggle: задействованы новые типы
- radio-button: задействованы новые типы
- switcher-row: удален проп failed из компонента

Closes #110