### PR TITLE
#226 Carousel: не срабатывает первый клик после прокрутки на touch-устройствах

### DIFF
--- a/src/carousel/__test__/draggable.test.tsx
+++ b/src/carousel/__test__/draggable.test.tsx
@@ -1,8 +1,68 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 import { isFunction } from 'lodash';
 import Draggable from '../draggable';
 import DraggableEvent from '../helpers/draggable-event';
+import { IPoint } from '../../helpers/point';
+
+class StubDraggable extends Component implements Draggable {
+  isGrabbed = false;
+  hasTransition = false;
+  needPreventClick = false;
+  currentOffset: IPoint = { x: 0, y: 0 };
+  clientPosition: IPoint = { x: 0, y: 0 };
+  draggableRef: React.RefObject<HTMLDivElement> = { current: null };
+  offList: Array<VoidFunction> = [];
+
+  componentDidMount() {
+    return void 0;
+  }
+  componentWillUnmount() {
+    return void 0;
+  }
+  initGlobalListeners() {
+    return void 0;
+  }
+  passControl() {
+    return void 0;
+  }
+  startCapture() {
+    return void 0;
+  }
+  handleMove() {
+    return void 0;
+  }
+  handleMoveEnd() {
+    return void 0;
+  }
+  handleClickCapture() {
+    return void 0;
+  }
+  getClientDelta() {
+    return { dx: 0, dy: 0 };
+  }
+  isTransitionEnabled() {
+    return false;
+  }
+  saveClientPosition() {
+    return void 0;
+  }
+  toggleGrabbed() {
+    return void 0;
+  }
+  toggleTransition() {
+    return void 0;
+  }
+  togglePreventClickNeed() {
+    return void 0;
+  }
+  setOffset() {
+    return void 0;
+  }
+  render() {
+    return <></>;
+  }
+}
 
 /**
  * Возвращает поддельное событие мыши.
@@ -333,5 +393,22 @@ describe('<Draggable />', () => {
     expect(Draggable.prototype.isTransitionEnabled.call(fake)).toBe(false);
     fake.hasTransition = true;
     expect(Draggable.prototype.isTransitionEnabled.call(fake)).toBe(true);
+  });
+
+  it('should not change "prevent need click" state on drag when is not touch', () => {
+    const stub = new StubDraggable({});
+    const spy = jest.spyOn(stub, 'togglePreventClickNeed');
+    stub.isGrabbed = true;
+
+    expect(spy).toBeCalledTimes(0);
+
+    const touchEvent = new TouchEvent('touchmove');
+    Draggable.prototype.handleMove.call(stub, touchEvent);
+    expect(spy).toBeCalledTimes(0);
+
+    const mouseEvent = new MouseEvent('mousemove');
+    Draggable.prototype.handleMove.call(stub, mouseEvent);
+    expect(spy).toBeCalledTimes(1);
+    expect(spy).toBeCalledWith(true);
   });
 });

--- a/src/carousel/draggable.tsx
+++ b/src/carousel/draggable.tsx
@@ -164,12 +164,13 @@ export class Draggable extends Component<DraggableProps> {
         client: getEventClientPos(event),
       });
 
-      this.togglePreventClickNeed(true);
-
-      // prevent selection
       if (!isTouchEvent(event)) {
+        // предотвращаем выделение текста на странице
         event.preventDefault();
-        (window.getSelection() as Selection).removeAllRanges();
+        window.getSelection()?.removeAllRanges();
+
+        // предотвращаем клик только на НЕ touch-устройствах тк на них срабатывает клик при перетаскивании
+        this.togglePreventClickNeed(true);
       }
 
       onDragMove && onDragMove(customEvent);

--- a/src/checkbox/__stories__/index.stories.tsx
+++ b/src/checkbox/__stories__/index.stories.tsx
@@ -18,6 +18,8 @@ export function Primary() {
   );
 }
 
+Primary.storyName = 'Простой пример';
+
 export function TestInputProps() {
   function noop() {
     return void 0;

--- a/src/chips/__stories__/index.stories.tsx
+++ b/src/chips/__stories__/index.stories.tsx
@@ -69,7 +69,7 @@ export function WithCross() {
   );
 }
 
-WithCross.displayName = 'С крестиком';
+WithCross.storyName = 'С крестиком';
 
 export function TruncatedText() {
   const longText =
@@ -102,4 +102,4 @@ export function TruncatedText() {
   );
 }
 
-TruncatedText.displayName = 'Обрезка текста';
+TruncatedText.storyName = 'Обрезка текста';

--- a/src/field-grid/index.tsx
+++ b/src/field-grid/index.tsx
@@ -56,7 +56,7 @@ const TypeCheck = {
 
 /**
  * Компонент сетки полей.
- * @deprecated
+ * @deprecated В макетах больше не используются "склеивания" полей.
  * @param props Свойства.
  * @param props.children Содержимое, дочерними элементами могут быть только FieldGrid.Row.
  * @param props.rootProps Свойства корневого элемента.

--- a/src/hooks/breakpoint/types.ts
+++ b/src/hooks/breakpoint/types.ts
@@ -1,5 +1,3 @@
-export type Breakpoint = 'mxs' | 'ms' | 'mm' | 'ml' | 'xs' | 's' | 'm' | 'l' | 'xl';
-
 export type Direction = '+' | '-';
 
 export type ChangeHandler = (event: { matches: boolean }) => void;

--- a/src/hooks/breakpoint/utils.ts
+++ b/src/hooks/breakpoint/utils.ts
@@ -1,12 +1,6 @@
 import { subscribe } from '../../helpers/media-query-list';
-import {
-  Breakpoint,
-  ChangeHandler,
-  Direction,
-  Registry,
-  RegistryItem,
-  Subscription,
-} from './types';
+import { Breakpoint } from '../../types';
+import { ChangeHandler, Direction, Registry, RegistryItem, Subscription } from './types';
 
 const Resolution: Record<Breakpoint, number> = {
   mxs: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import type { InputHTMLAttributes } from 'react';
 
+/**
+ * Обозначение точки остановки в соответствии дизайн-гайдами.
+ */
+export type Breakpoint = 'mxs' | 'ms' | 'mm' | 'ml' | 'xs' | 's' | 'm' | 'l' | 'xl';
+
 /** Свойства компонента для маркировки атрибутом "data-testid". */
 export interface WithTestId {
   /** Идентификатор для систем автоматизированного тестирования. */


### PR DESCRIPTION
- carousel/draggable: правки обработки перетаскивания для исправления бага: не срабатывал первый клик после перетаскивания на touch-устройствах

#### Прочее

- мелкие правки stories (patch)
- field-grid: добавлено пояснение для deprecated (patch)
- hooks/breakpoint: тип Breakpoint вынесен в src/types тк будет использоваться в Layout (patch)
