### PR TITLE
Шаг 1 #218 MaskedField: заменить TextField на Input

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,8 +8,9 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
@@ -36,4 +37,4 @@ jobs:
       - name: Publish build
         run: npm publish ./build --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -13,23 +13,24 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
+      - uses: actions/checkout@v3
 
-    - name: Install dependencies
-      run: npm ci
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run Playwright tests
-      run: npx playwright test
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
 
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,3 @@
 build
 build-storybook
 coverage
-
-# Configs
-*.yaml
-*.yml

--- a/package.json
+++ b/package.json
@@ -8,6 +8,24 @@
   "engines": {
     "node": ">=16.15.1"
   },
+  "scripts": {
+    "prepare": "husky install",
+    "export:colors": "node .template/build.mjs",
+    "build:before": "rimraf build",
+    "build:main": "tsc --project tsconfig.build.json",
+    "build:after": "node dist.mjs",
+    "build": "npm run build:before && npm run build:main && npm run build:after",
+    "test": "BROWSERSLIST_ENV=\"test\" npx jest",
+    "coverage": "jest --clearCache && BROWSERSLIST_ENV=\"test\" npx jest --coverage",
+    "type-check": "tsc -p . --noEmit",
+    "lint": "npm run lint:scripts && npm run lint:styles",
+    "lint:scripts": "eslint --cache src/ --ext .js,.jsx,.ts,.tsx",
+    "lint:styles": "stylelint 'src/**/*.{css,scss}'",
+    "storybook": "BROWSERSLIST_ENV=\"storybook\" npx start-storybook -p 9009 -c .storybook",
+    "storybook:build": "BROWSERSLIST_ENV=\"storybook\" npx build-storybook --quiet --loglevel error -o build-storybook",
+    "prettier": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,css,scss}\" --loglevel error",
+    "prettier:check": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,css,scss}\" --loglevel error"
+  },
   "dependencies": {
     "@floating-ui/react-dom": "^1.0.0",
     "@floating-ui/react-dom-interactions": "^0.10.3",
@@ -86,23 +104,5 @@
   "peerDependencies": {
     "react": ">=17",
     "react-dom": ">=17"
-  },
-  "scripts": {
-    "prepare": "husky install",
-    "export:colors": "node .template/build.mjs",
-    "build:before": "rimraf build",
-    "build:main": "tsc --project tsconfig.build.json",
-    "build:after": "node dist.mjs",
-    "build": "npm run build:before && npm run build:main && npm run build:after",
-    "test": "BROWSERSLIST_ENV=\"test\" npx jest",
-    "coverage": "jest --clearCache && BROWSERSLIST_ENV=\"test\" npx jest --coverage",
-    "type-check": "tsc -p . --noEmit",
-    "lint": "npm run lint:scripts && npm run lint:styles",
-    "lint:scripts": "eslint --cache src/ --ext .js,.jsx,.ts,.tsx",
-    "lint:styles": "stylelint 'src/**/*.{css,scss}'",
-    "storybook": "BROWSERSLIST_ENV=\"storybook\" npx start-storybook -p 9009 -c .storybook",
-    "storybook:build": "BROWSERSLIST_ENV=\"storybook\" npx build-storybook --quiet --loglevel error -o build-storybook",
-    "prettier": "prettier --write \"./src/**/*.{js,jsx,ts,tsx,css,scss}\" --loglevel error",
-    "prettier:check": "prettier --check \"./src/**/*.{js,jsx,ts,tsx,css,scss}\" --loglevel error"
   }
 }

--- a/src/base-input/__test__/index.test.tsx
+++ b/src/base-input/__test__/index.test.tsx
@@ -1,7 +1,6 @@
 import React, { createRef } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { BaseInput } from '..';
-import { RestPlaceholder } from '../base-input';
 import { fitElementHeight } from '../../helpers/fit-element-height';
 
 jest.mock('../../helpers/fit-element-height', () => {
@@ -41,14 +40,14 @@ describe('BaseInput', () => {
     expect(fitElementHeight).toBeCalledTimes(2);
   });
 
-  it('should render rest placeholder', () => {
-    const { container, getByTestId } = render(<BaseInput value='hello' restPlaceholder=' world' />);
+  it('should render rest placeholder for controlled fields only (when value provided)', () => {
+    const { container, rerender } = render(
+      <BaseInput value='hello' onChange={jest.fn()} restPlaceholder=' world' />,
+    );
 
     expect(container.querySelector('.rest-placeholder')?.textContent).toBe('hello world');
 
-    const input = getByTestId('base-input:field') as HTMLInputElement;
-    input.value = 'some text';
-    fireEvent.input(getByTestId('base-input:field'));
+    rerender(<BaseInput value='some text' onChange={jest.fn()} restPlaceholder=' world' />);
 
     expect(container.querySelector('.rest-placeholder')?.textContent).toBe('some text world');
   });
@@ -57,6 +56,7 @@ describe('BaseInput', () => {
     const { container } = render(
       <BaseInput
         value='foo'
+        onChange={jest.fn()}
         restPlaceholder={{
           value: ' bar',
           shiftValue: 'foo',
@@ -103,23 +103,5 @@ describe('BaseInput', () => {
     rerender(<BaseInput multiline data-testid='foo-bar' />);
     expect(find('[data-testid="foo-bar"] textarea')).toHaveLength(1);
     expect(find('[data-testid="foo-bar"] [data-testid="base-input:field"]')).toHaveLength(1);
-  });
-});
-
-describe('RestPlaceholder', () => {
-  it('should handle element missing in inputRef', () => {
-    expect(() => {
-      render(
-        <RestPlaceholder
-          inputRef={{ current: null }}
-          value='hello'
-          defaultValue={undefined}
-          definition={{
-            value: 'hi',
-            shiftValue: 'hello',
-          }}
-        />,
-      );
-    }).not.toThrow();
   });
 });

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -183,21 +183,21 @@ export function Input({
           required={required}
           type={type}
           value={value}
-          onFocus={(event: any) => {
+          onFocus={event => {
             onFocus?.(event);
             updateFilled(event);
             setFocused(true);
           }}
-          onBlur={(event: any) => {
+          onBlur={event => {
             onBlur?.(event);
             updateFilled(event);
             setFocused(false);
           }}
-          onInput={(event: any) => {
+          onInput={event => {
             onInput?.(event);
             updateFilled(event);
           }}
-          onChange={(event: any) => {
+          onChange={event => {
             onChange?.(event);
             updateFilled(event);
           }}

--- a/src/input/utils.ts
+++ b/src/input/utils.ts
@@ -1,4 +1,12 @@
-import { MouseEventHandler, RefObject, useCallback, useEffect, useState } from 'react';
+import {
+  EventHandler,
+  MouseEventHandler,
+  RefObject,
+  SyntheticEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { COLORS } from '../colors';
 
 /**
@@ -47,7 +55,7 @@ export function definePlaceholderColor({
  * @return Кортеж: состояние; функция обновления состояния.
  */
 export function useFilledState(
-  ref: RefObject<HTMLInputElement | HTMLTextAreaElement>,
+  ref: RefObject<HTMLInputElement> | RefObject<HTMLTextAreaElement>,
   {
     value,
     defaultValue,
@@ -55,15 +63,12 @@ export function useFilledState(
     value: unknown;
     defaultValue: unknown;
   },
-): [boolean, MouseEventHandler<HTMLInputElement | HTMLTextAreaElement>] {
+): [boolean, EventHandler<SyntheticEvent<{ value: string }>>] {
   const [filled, setFilled] = useState<boolean>(() => defineFilled(value, defaultValue));
 
-  const updateFilled = useCallback<MouseEventHandler<HTMLInputElement | HTMLTextAreaElement>>(
-    event => {
-      setFilled(Boolean(event.currentTarget.value));
-    },
-    [],
-  );
+  const updateFilled = useCallback<EventHandler<SyntheticEvent<{ value: string }>>>(event => {
+    setFilled(Boolean(event.currentTarget.value));
+  }, []);
 
   useEffect(() => {
     setFilled(Boolean(ref.current?.value));

--- a/src/masked-field/__stories__/index.stories.tsx
+++ b/src/masked-field/__stories__/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MaskedField } from '..';
 
 export default {
-  title: 'common/MaskedField',
+  title: 'deprecated/MaskedField',
   component: MaskedField,
   parameters: {
     layout: 'padded',

--- a/src/masked-field/index.tsx
+++ b/src/masked-field/index.tsx
@@ -22,6 +22,7 @@ const maskCommons = { placeholder: '_', pattern: /\d/ };
 
 /**
  * Компонент текстового поля (TextField) с маской.
+ * @deprecated Теперь нужно использовать MaskedInput.
  * @param props Свойства.
  * @param props.mask Маска.
  * @param props.value Значение.


### PR DESCRIPTION
- `base-input`: теперь rest placeholder выводится только для контролируемых полей
- `input`: убраны any
- `masked-field`: помечен как deprecated
- `pacakge.json`: скрипты перенесены выше
- `.github`: подняты версии экшнов
- `.prettierignore`: больше не игнорируется yml, yaml