### PR TITLE
Шаг 2 #217 PhoneInput: обновить в соответствии с новыми дизайн-гайдами

### DIFF
--- a/src/expandable/utils.ts
+++ b/src/expandable/utils.ts
@@ -66,7 +66,7 @@ export function useExpandable({
         setHiddenCount(state.lastVisibleIndex !== -1 ? items.length - state.lastVisibleIndex : 0);
       }
     }
-  }, [expanded, gap]);
+  }, [expanded, gap, wrapperRef, containerRef, openerRef]);
 
   // пересчитываем после каждого rerender'а
   useIsomorphicLayoutEffect(calc);

--- a/src/expandable/utils.ts
+++ b/src/expandable/utils.ts
@@ -1,6 +1,6 @@
 import { RefObject, useCallback, useEffect, useState } from 'react';
 import { useIsomorphicLayoutEffect } from '../hooks';
-import on from '../helpers/on';
+import { on } from '../helpers/on';
 import styles from './expandable-group.module.scss';
 
 export interface ViewState {

--- a/src/input/__test__/index.test.tsx
+++ b/src/input/__test__/index.test.tsx
@@ -181,4 +181,17 @@ describe('Input', () => {
     expect(find('[data-testid="email"] [data-testid="base-input"] input')).toHaveLength(1);
     expect(find('[data-testid="email"] [data-testid="base-input:field"]')).toHaveLength(1);
   });
+
+  it('should handle "focused" prop', () => {
+    const { getByTestId, rerender } = render(<Input />);
+
+    expect(getByTestId('input').classList.contains('focused')).toBe(false);
+    fireEvent.focus(getByTestId('base-input:field'));
+    expect(getByTestId('input').classList.contains('focused')).toBe(true);
+    fireEvent.blur(getByTestId('base-input:field'));
+    expect(getByTestId('input').classList.contains('focused')).toBe(false);
+
+    rerender(<Input focused />);
+    expect(getByTestId('input').classList.contains('focused')).toBe(true);
+  });
 });

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -110,6 +110,7 @@ export function Input({
   caption,
   blockProps,
   'data-testid': testId = 'input',
+  focused: focusedProp,
   ...restProps
 }: InputProps) {
   const ref = useRef<HTMLInputElement>(null);
@@ -137,7 +138,7 @@ export function Input({
       caption={caption}
       disabled={disabled}
       failed={failed}
-      focused={focused}
+      focused={focusedProp ?? focused}
       label={label}
       labelAsPlaceholder={!focused && !filled}
       labelProps={{ htmlFor: id }}

--- a/src/masked-input/__stories__/index.stories.tsx
+++ b/src/masked-input/__stories__/index.stories.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { MaskedInput } from '..';
+import { DropdownItem } from '../../dropdown-item';
+import { Select } from '../../select';
 import { TextButton } from '../../text-button';
 
 export default {
@@ -74,3 +76,64 @@ export function TestUncontrolled() {
 }
 
 TestUncontrolled.storyName = 'Тест: неконтролируемое поле';
+
+export function TestMaskChange() {
+  const masks: ReadonlyArray<{ name: string; mask: string }> = [
+    {
+      name: 'Паспорт',
+      mask: '____ ______',
+    },
+    {
+      name: 'Дата',
+      mask: '__ / __ / ____',
+    },
+    {
+      name: 'Телефон',
+      mask: '+7 (___) ___-__-__',
+    },
+    {
+      name: 'Карта',
+      mask: '____ ____ ____ ____',
+    },
+  ];
+
+  const [value, setValue] = useState('');
+  const [mask, setMask] = useState(masks[0]);
+
+  return (
+    <>
+      <Select
+        opener={<Select.TextButton size='s' />}
+        value={mask.name}
+        onValueChange={maskName => {
+          const newMask = masks.find(i => i.name === maskName);
+
+          if (newMask) {
+            setMask(newMask);
+            setValue(newMask.mask.replace(/[^_]/g, '').replace(/_/g, '0'));
+          }
+        }}
+      >
+        {masks.map((item, index) => (
+          <DropdownItem key={index} value={item.name}>
+            {item.name}
+          </DropdownItem>
+        ))}
+      </Select>
+
+      <MaskedInput
+        style={{ marginTop: '12px' }}
+        label={mask.name}
+        mask={mask.mask}
+        value={value}
+        onChange={(event, data) => {
+          setValue(data.cleanValue);
+        }}
+      />
+
+      <p>Значение: {value || '[пусто]'}</p>
+    </>
+  );
+}
+
+TestMaskChange.storyName = 'Тест: смена маски';

--- a/src/masked-input/__test__/hook.test.tsx
+++ b/src/masked-input/__test__/hook.test.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import { createEvent, fireEvent, render } from '@testing-library/react';
 import { useInputMask } from '../hook';
+import { UseInputMaskOptions, UseInputMaskResult } from '../types';
 
 describe('useInputMask', () => {
   it('should not throw when input ref is empty', () => {
     function WrongUsage({ value, defaultValue }: { value?: string; defaultValue?: string }) {
-      useInputMask({
+      const { bind } = useInputMask({
         value,
         defaultValue,
         maskOptions: {
@@ -15,12 +16,23 @@ describe('useInputMask', () => {
         },
       });
 
-      return <div>There is no input</div>;
+      return (
+        <div>
+          <p>There is an input without ref</p>
+          <input type='text' data-testid='test-input' onChange={bind.onChange} />
+        </div>
+      );
     }
 
-    const { rerender } = render(<WrongUsage value='111' />);
+    const { rerender, getByTestId } = render(<WrongUsage value='111' />);
 
-    expect(() => rerender(<WrongUsage value='222' />)).not.toThrow();
+    expect(() => {
+      rerender(<WrongUsage value='222' />);
+    }).not.toThrow();
+
+    expect(() => {
+      fireEvent.change(getByTestId('test-input'), { target: { value: '444' } });
+    }).not.toThrow();
   });
 
   it('should handle document "selectionchange" properly', () => {
@@ -52,5 +64,59 @@ describe('useInputMask', () => {
     expect(document.activeElement).toBe(getByTestId('test-input'));
     fireEvent(document, createEvent('selectionchange', document));
     expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should return suitable result for options immediately (without rerender)', () => {
+    const spy = jest.fn((result: UseInputMaskResult) => result);
+
+    function TestComponent(props: UseInputMaskOptions) {
+      const { store, bind } = useInputMask(props);
+
+      spy({ store, bind });
+
+      return <input data-testid='test-input' {...bind} />;
+    }
+
+    expect(spy).toBeCalledTimes(0);
+
+    const { rerender } = render(
+      <TestComponent
+        value='1111'
+        maskOptions={{
+          mask: '____',
+          pattern: '\\d',
+          placeholder: '_',
+        }}
+      />,
+    );
+    expect(spy).toBeCalledTimes(1);
+    expect(spy.mock.calls[0][0].bind.value).toBe('1111');
+
+    rerender(
+      <TestComponent
+        value='2222'
+        maskOptions={{
+          mask: '+998-__-___-____',
+          pattern: '\\d',
+          placeholder: '_',
+        }}
+      />,
+    );
+    expect(spy).toBeCalledTimes(2);
+    expect(spy.mock.calls[1][0].bind.value).toBe('+998-22-22');
+
+    rerender(
+      <TestComponent
+        value='3333'
+        maskOptions={{
+          mask: '+998-__-___-____',
+          pattern: '\\d',
+          placeholder: '_',
+        }}
+      />,
+    );
+    expect(spy).toBeCalledTimes(4);
+    expect(spy.mock.calls[2][0].bind.value).toBe('+998-22-22');
+    expect(spy.mock.calls[3][0].bind.value).toBe('+998-33-33');
   });
 });

--- a/src/masked-input/__test__/index.test.tsx
+++ b/src/masked-input/__test__/index.test.tsx
@@ -78,4 +78,25 @@ describe('MaskedInput', () => {
     fireEvent.blur(getByTestId('base-input:field'));
     expect(spy).toBeCalledTimes(1);
   });
+
+  it('should handle "baseInputProps.restPlaceholder" prop', () => {
+    const { container, rerender } = render(
+      <MaskedInput mask='____' value='22' onChange={jest.fn()} />,
+    );
+
+    expect(container.querySelector('.rest-placeholder')?.textContent).toBe('22__');
+
+    rerender(
+      <MaskedInput
+        mask='____'
+        value='22'
+        onChange={jest.fn()}
+        baseInputProps={{
+          restPlaceholder: { value: '', shiftValue: '' },
+        }}
+      />,
+    );
+
+    expect(container.querySelector('.rest-placeholder')?.textContent).toBe('');
+  });
 });

--- a/src/masked-input/hook.ts
+++ b/src/masked-input/hook.ts
@@ -17,41 +17,60 @@ export function useInputMask({
   value,
   defaultValue,
 }: UseInputMaskOptions): UseInputMaskResult {
-  // запоминаем опции тк RegExp - объект и при использовании синтаксиса он будет каждый раз новым
+  // запоминаем опции тк RegExp - объект и при использовании литерала он будет каждый раз новым
   const maskOptions = useMemo<ReducerOptions>(
     () => ({
       mask: maskOptionsProp.mask,
       pattern: new RegExp(maskOptionsProp.pattern),
       placeholder: maskOptionsProp.placeholder,
     }),
-    [...Object.values(maskOptionsProp)],
+    [maskOptionsProp.mask, maskOptionsProp.pattern, maskOptionsProp.placeholder],
   );
 
   const input = useRef<HTMLInputElement>(null);
   const [initialValue] = useState(defaultValue);
-  const [store, setStore] = useState(() => createInputMaskStore(maskOptions));
 
-  // состояние нужно для того, чтобы вызывать render при изменении состояния
-  // ВАЖНО: используем именно state, тк reducer может вернуть состояние без изменений
-  const [, setState] = useState(() => store.getState());
+  // ВАЖНО: рефы нужны чтобы не вызывать callback useMemo при изменении значений
+  const valueRef = useRef(value);
+  const initialValueRef = useRef(initialValue);
+  valueRef.current = value;
+  initialValueRef.current = initialValue;
 
   // mask options change: init new store
-  useIsomorphicLayoutEffect(() => {
-    const nextStore = createInputMaskStore(maskOptions);
+  const store = useMemo(() => {
+    const newStore = createInputMaskStore(maskOptions);
 
-    nextStore.dispatch(actions.manualChange({ value: value ?? initialValue ?? '' }));
+    newStore.dispatch(
+      actions.manualChange({
+        value: valueRef.current ?? initialValueRef.current ?? '',
+      }),
+    );
 
-    setStore(nextStore);
-    setState(nextStore.getState());
-
-    return nextStore.subscribe(() => {
-      setState(nextStore.getState());
-
-      if (input.current) {
-        State.applyDiff(nextStore.getState(), input.current);
-      }
-    });
+    return newStore;
   }, [maskOptions]);
+
+  // ВАЖНО: состояние нужно для того, чтобы вызывать render при изменении состояния хранилища
+  // ВАЖНО: используем именно store.getState(), тк reducer может вернуть состояние без изменений
+  const [, setState] = useState(() => store.getState());
+
+  useIsomorphicLayoutEffect(() => {
+    const offList: VoidFunction[] = [
+      store.subscribe(() => {
+        setState(store.getState());
+
+        if (input.current) {
+          State.applyDiff(store.getState(), input.current);
+        }
+      }),
+      on(document, 'selectionchange', () => {
+        if (input.current && input.current === document.activeElement) {
+          store.dispatch(actions.inputSelectionChange({ input: input.current }));
+        }
+      }),
+    ];
+
+    return () => offList.forEach(fn => fn());
+  }, [store]);
 
   // value prop change: update state
   useIsomorphicLayoutEffect(() => {
@@ -61,18 +80,7 @@ export function useInputMask({
     ) {
       store.dispatch(actions.manualChange({ value }));
     }
-  }, [value, store]);
-
-  // document selectionchange: update state
-  useIsomorphicLayoutEffect(() => {
-    const off = on(document, 'selectionchange', () => {
-      if (input.current && input.current === document.activeElement) {
-        store.dispatch(actions.inputSelectionChange({ input: input.current }));
-      }
-    });
-
-    return off;
-  }, [store]);
+  }, [value, store, maskOptions]);
 
   // input change: update state
   const onChange = useCallback<ChangeEventHandler<HTMLInputElement>>(

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useImperativeHandle } from 'react';
 import { Input } from '../input';
 import { Value } from '@krutoo/input-mask/dist/dom/utils';
 import { useInputMask } from './hook';
-import { MaskedInputProps } from './types';
+import { MaskData, MaskedInputProps } from './types';
 
 /**
  * Поле ввода текста по маске.
@@ -34,23 +34,23 @@ export function MaskedInput({
   );
 
   const getData = useCallback(
-    () => ({
+    (): MaskData => ({
       value: store.getState().value,
       cleanValue: Value.toClean({ mask, placeholder }, store.getState().value),
       completed: store.getState().value.length === mask.length,
     }),
-    [store, mask, pattern, placeholder],
+    [store, mask, placeholder],
   );
 
   return (
     <Input
       {...props}
       baseInputProps={{
-        restPlaceholder: {
+        ...baseInputProps,
+        restPlaceholder: baseInputProps?.restPlaceholder ?? {
           value: mask.slice(store.getState().value.length),
           shiftValue: store.getState().value,
         },
-        ...baseInputProps,
       }}
       inputRef={bind.ref}
       value={bind.value}

--- a/src/masked-input/utils.ts
+++ b/src/masked-input/utils.ts
@@ -41,12 +41,18 @@ function createDomReducer(options: ReducerOptions) {
     } else if (actions.inputSelectionChange.is(action)) {
       result = State.fromTarget(action.payload.input);
     } else if (actions.manualChange.is(action)) {
+      // мы не знаем какое значение передано (clean или masked) поэтому берем из него только подходящие символы
+      const validCleanValue = action.payload.value
+        .split('')
+        .filter(c => c.match(options.pattern))
+        .join('');
+
+      const newMaskedValue = Value.toMasked(options, validCleanValue);
       const firstPlace = options.mask.indexOf(options.placeholder);
-      const maskedValue = Value.toMasked(options, action.payload.value);
 
       result = processState(
         State.of(state.value, Range.of(firstPlace, state.value.length)),
-        State.of(maskedValue, Range.of(maskedValue.length)),
+        State.of(newMaskedValue, Range.of(newMaskedValue.length)),
       );
     }
 

--- a/src/select/__stories__/index.stories.tsx
+++ b/src/select/__stories__/index.stories.tsx
@@ -147,7 +147,7 @@ export function DifferentStates() {
         },
         {
           type: 'toggle',
-          label: 'Загрузка',
+          label: 'Загрузка списка',
           bind: [loading, setLoading],
         },
       ]}
@@ -172,13 +172,13 @@ DifferentStates.storyName = 'Различные состояния';
 export function TestNativeCompare() {
   return (
     <div style={{ display: 'flex', gap: 20, justifyContent: 'center', alignItems: 'center' }}>
-      <Select opener={<Select.FieldBlock size='s' />}>
-        <DropdownItem>Один</DropdownItem>
-        <DropdownItem>Два</DropdownItem>
-        <DropdownItem>Три</DropdownItem>
+      <Select defaultValue='Один' opener={<Select.FieldBlock size='s' />}>
+        <DropdownItem size='s'>Один</DropdownItem>
+        <DropdownItem size='s'>Два</DropdownItem>
+        <DropdownItem size='s'>Три</DropdownItem>
       </Select>
 
-      <select style={{ width: 240 }}>
+      <select style={{ width: 240 }} defaultValue='Один'>
         <option>Один</option>
         <option>Два</option>
         <option>Три</option>
@@ -214,12 +214,17 @@ export function TestInModal() {
 
   return (
     <Modal>
-      <Modal.Header title='Тест' divided />
+      <Modal.Header title='Тест' subtitle='Select внутри Modal' divided />
       <Modal.Body>
         <div style={{ padding: 16 }}>
           <LoremIpsum paragraphCount={10} />
 
-          <Select value={value} onValueChange={setValue} dropdownProps={{ style: { width: 320 } }}>
+          <Select
+            label='Номер'
+            value={value}
+            onValueChange={setValue}
+            dropdownProps={{ style: { width: 320 } }}
+          >
             <DropdownItem>Ноль</DropdownItem>
             <DropdownItem>Один</DropdownItem>
             <DropdownItem>Два</DropdownItem>

--- a/src/select/__test__/index.test.tsx
+++ b/src/select/__test__/index.test.tsx
@@ -413,4 +413,36 @@ describe('Select', () => {
     fireEvent.keyDown(getByTestId(baseElement, 'dropdown'), { code: 'Tab' });
     expect(document.activeElement).toBe(getByTestId(container, 'field-block:block'));
   });
+
+  it('should handle "defaultValue" prop', () => {
+    const spy = jest.fn();
+
+    const { baseElement, container } = render(
+      <Select defaultValue='Third' onValueChange={spy}>
+        <DropdownItem>First</DropdownItem>
+        <DropdownItem>Second</DropdownItem>
+        <DropdownItem>Third</DropdownItem>
+      </Select>,
+    );
+
+    expect(spy).toBeCalledTimes(0);
+    expect(getByTestId(container, 'field-block:block').textContent).toBe('Third');
+
+    fireEvent.mouseDown(getByTestId(container, 'field-block:block'));
+    fireEvent.click(queryAllByTestId(baseElement, 'dropdown-item')[2]);
+    expect(spy).toBeCalledTimes(1);
+    expect(getByTestId(container, 'field-block:block').textContent).toBe('Third');
+  });
+
+  it('should handle "renderValue" prop', () => {
+    const { container } = render(
+      <Select value='Second' renderValue={value => <b>selected: {value}</b>}>
+        <DropdownItem>First</DropdownItem>
+        <DropdownItem>Second</DropdownItem>
+        <DropdownItem>Third</DropdownItem>
+      </Select>,
+    );
+
+    expect(getByTestId(container, 'field-block:block').textContent).toBe('selected: Second');
+  });
 });

--- a/src/select/__test__/utils.test.tsx
+++ b/src/select/__test__/utils.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { SelectOpenerBinding } from '../types';
+import { SelectContext } from '../utils';
+
+describe('SelectContext', () => {
+  it('should contain defaults', () => {
+    const spy = jest.fn((bind: SelectOpenerBinding) => bind);
+
+    function TestComponent() {
+      const bind = useContext(SelectContext);
+
+      spy(bind);
+
+      return (
+        <div data-testid='test-stub' onMouseDown={bind.onMouseDown} onKeyDown={bind.onKeyDown}>
+          Hello
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<TestComponent />);
+
+    // check defaults
+    expect(spy).toBeCalledTimes(1);
+    expect(typeof spy.mock.calls[0][0].onKeyDown === 'function').toBe(true);
+    expect(typeof spy.mock.calls[0][0].onMouseDown === 'function').toBe(true);
+
+    // call default callbacks
+    expect(() => {
+      fireEvent.mouseDown(getByTestId('test-stub'));
+      fireEvent.keyDown(getByTestId('test-stub'));
+    }).not.toThrow();
+  });
+});

--- a/src/select/parts/__test__/button.test.tsx
+++ b/src/select/parts/__test__/button.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { fireEvent, getByTestId, queryAllByTestId, render } from '@testing-library/react';
 import { SelectTextButton } from '../button';
 import { Select } from '../../select';
@@ -21,5 +21,37 @@ describe('SelectTextButton', () => {
     fireEvent.keyDown(getByTestId(container, 'text-button'), { code: 'Enter' });
     expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
     expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should handle children prop', () => {
+    const { container, rerender } = render(
+      <Select value='Foo' opener={<SelectTextButton />}>
+        <DropdownItem>Foo</DropdownItem>
+        <DropdownItem>Bar</DropdownItem>
+      </Select>,
+    );
+    expect(getByTestId(container, 'text-button').textContent).toBe('Foo');
+
+    rerender(
+      <Select value='Foo' opener={<SelectTextButton>Hello, world</SelectTextButton>}>
+        <DropdownItem>Foo</DropdownItem>
+        <DropdownItem>Bar</DropdownItem>
+      </Select>,
+    );
+    expect(getByTestId(container, 'text-button').textContent).toBe('Hello, world');
+  });
+
+  it('should handle ref prop', () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    const { container } = render(
+      <Select opener={<SelectTextButton buttonRef={ref} />}>
+        <DropdownItem>Foo</DropdownItem>
+        <DropdownItem>Bar</DropdownItem>
+      </Select>,
+    );
+
+    expect(ref.current instanceof HTMLButtonElement).toBe(true);
+    expect(ref.current === getByTestId(container, 'text-button')).toBe(true);
   });
 });

--- a/src/select/parts/button.tsx
+++ b/src/select/parts/button.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useImperativeHandle, useRef } from 'react';
 import { TextButton, TextButtonAsButtonProps } from '../../text-button';
 import { SelectContext } from '../utils';
 import UpSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/Arrows/up';
@@ -9,33 +9,45 @@ import DownSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/Arrows/down';
  * @param props Свойства.
  * @return Элемент.
  */
-export function SelectTextButton(props: TextButtonAsButtonProps) {
+export function SelectTextButton({
+  buttonRef: buttonRefProp,
+  children,
+  onKeyDown,
+  onMouseDown,
+  ...props
+}: TextButtonAsButtonProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const binding = useContext(SelectContext);
   const ArrowSVG = binding.opened ? UpSVG : DownSVG;
 
-  // @todo прокидывать ref в props.buttonRef при необходимости
+  useImperativeHandle<HTMLElement | null, HTMLElement | null>(
+    buttonRefProp,
+    () => buttonRef.current,
+  );
+  useImperativeHandle<HTMLElement | null, HTMLElement | null>(
+    binding.openerRef,
+    () => buttonRef.current,
+  );
 
   return (
     <TextButton
-      {...props}
-      as='button'
       iconGutter={4}
       endIcon={ArrowSVG}
-      {...{
-        onMouseDown: event => {
-          binding.onMouseDown?.(event);
-          props.onMouseDown?.(event);
-        },
-        onKeyDown: event => {
-          binding.onKeyDown?.(event);
-          props.onKeyDown?.(event);
-        },
+      {...props}
+      as='button'
+      onMouseDown={event => {
+        binding.onMouseDown?.(event);
+        onMouseDown?.(event);
+      }}
+      onKeyDown={event => {
+        binding.onKeyDown?.(event);
+        onKeyDown?.(event);
       }}
       disabled={binding.disabled}
-      buttonRef={binding.openerRef as any}
+      buttonRef={buttonRef}
       role='combobox'
     >
-      {binding.value || binding.label}
+      {children ?? (binding.value || binding.label)}
     </TextButton>
   );
 }

--- a/src/select/parts/menu.tsx
+++ b/src/select/parts/menu.tsx
@@ -13,7 +13,6 @@ import { Dropdown } from '../../dropdown';
 import { DropdownItem } from '../../dropdown-item';
 import { DropdownItemElement } from '../../dropdown-item/types';
 import { DropdownItemUtils } from '../../dropdown-item/utils';
-import { useFloatingDropdown } from '../../dropdown/utils';
 import { DropdownLoading } from '../../_internal/dropdown-loading';
 import { SelectMenuProps } from '../types';
 import classNames from 'classnames';
@@ -33,17 +32,14 @@ export function SelectMenu({
   loading,
   children,
   menuRef,
-  openerRef,
   value,
   onKeyDown,
   onItemSelect,
-  style,
   ...restProps
 }: SelectMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
   const osComponentRef = useRef<OverlayScrollbarsComponent>(null);
   const [activeIndex, setActiveIndex] = useState<number>(-1);
-  const { style: floatingStyle } = useFloatingDropdown(ref, openerRef);
   const items = Children.toArray(children).filter(DropdownItemUtils.is);
 
   useImperativeHandle(menuRef, () => ref.current);
@@ -85,7 +81,7 @@ export function SelectMenu({
           break;
       }
     },
-    [items, activeIndex, openerRef, onKeyDown],
+    [items, activeIndex, onKeyDown],
   );
 
   const handleItemClick = useCallback(
@@ -108,7 +104,6 @@ export function SelectMenu({
       onKeyDown={handleMenuKeyDown}
       className={classNames(styles.menu, restProps.className)}
       customScrollbarProps={{ osComponentRef }}
-      style={{ ...style, ...floatingStyle }}
     >
       {loading ? (
         <DropdownLoading data-testid='select:loading-area' />

--- a/src/select/types.ts
+++ b/src/select/types.ts
@@ -21,14 +21,14 @@ export interface SelectOpenerBinding {
   value: ReactNode;
   opened: boolean;
   menuFocused: boolean;
-  openerRef: RefObject<HTMLElement>;
-  onMouseDown?: HTMLAttributes<HTMLElement>['onMouseDown'];
-  onKeyDown?: HTMLAttributes<HTMLElement>['onKeyDown'];
+  openerRef: RefObject<HTMLElement | null>;
+  anchorRef: RefObject<HTMLElement | null>;
+  onMouseDown: Required<HTMLAttributes<HTMLElement>>['onMouseDown'];
+  onKeyDown: Required<HTMLAttributes<HTMLElement>>['onKeyDown'];
 }
 
 export interface SelectMenuProps extends DropdownProps {
   menuRef?: Ref<HTMLDivElement | null>;
-  openerRef: RefObject<HTMLElement | null>;
   value?: ReactNode;
   children?: ReactNode;
   loading?: boolean;
@@ -55,8 +55,14 @@ export interface SelectProps {
   /** Сработает при открытии/закрытии меню. */
   onMenuToggle?: (state: { opened: boolean }) => void;
 
-  /** Значение, выводимое в качестве выбранного. При отсутствии будет выведен label. */
-  value?: ReactNode;
+  /** Значение, выводимое в качестве выбранного. При отсутствии будет выведено значение defaultValue. */
+  value?: string;
+
+  /** Значение по умолчанию. При отсутствии будет выведено значение label. */
+  defaultValue?: string;
+
+  /** Получив значение являющееся текущим или пустую строку, должна вернуть ReactNode. */
+  renderValue?: (value: string) => ReactNode;
 
   /** Ярлык. */
   label?: string;

--- a/src/select/utils.ts
+++ b/src/select/utils.ts
@@ -6,4 +6,7 @@ export const SelectContext = createContext<SelectOpenerBinding>({
   opened: false,
   menuFocused: false,
   openerRef: createRef(),
+  anchorRef: createRef(),
+  onMouseDown: () => void 0,
+  onKeyDown: () => void 0,
 });


### PR DESCRIPTION
- `expandable`: правки использования хуков
- `input`: добавлена обработка пропса focused (зафиксировано тестами)
- `select`: `SelectProps` теперь содержит `defaultValue`
- `select`: `SelectProps` теперь содержит `renderValue`
- `select`: `SelectOpenerBinding` теперь содержит `anchorRef`
- `select`: `SelectOpenerBinding` - пропсы `onMouseDown, onKeyDown` теперь обязательны
- `select`: правки контекста в соответствии с новыми типам
- `select/parts/button`: теперь принимает пропсы `children, buttonRef, endIcon, iconGutter`
- `masked-input`: теперь не вызывает лишних перерендеров которые влекли скрытые баги (зафиксировано тестами)
- `select`: логика позиционирования меню вынесена из `SelectMenu` в `Select` чтобы соответствовать принципу передачи ref'ов
- `select`: добавлена возможность передавать `defaultValue` в `Select`