### PR TITLE
Шаг 4 #217 PhoneInput: обновить в соответствии с новыми дизайн-гайдами

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['list'], ['html', { open: process.env.CI ? 'never' : 'on-failure' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/src/base-input/base-input.tsx
+++ b/src/base-input/base-input.tsx
@@ -85,10 +85,14 @@ export function BaseInput({
   return (
     <div style={style} className={cx('reset', 'root', className)} data-testid={testId}>
       {/* ВАЖНО: restPlaceholder может накладываться на placeholder - компонент позволяет это делать т.к. они могут быть связаны */}
-      {!props.multiline && restPlaceholder && (
+      {!props.multiline && restPlaceholder && restPlaceholder.value && (
         <span aria-hidden className={cx('rest-placeholder')}>
-          <span className={cx('shift-part')}>{restPlaceholder.shiftValue}</span>
-          <span className={cx('main-part')}>{restPlaceholder.value}</span>
+          <span data-testid='rest-placeholder-shift' className={cx('shift-part')}>
+            {restPlaceholder.shiftValue}
+          </span>
+          <span data-testid='rest-placeholder' className={cx('main-part')}>
+            {restPlaceholder.value}
+          </span>
         </span>
       )}
       {field}

--- a/src/masked-input/__test__/index.test.tsx
+++ b/src/masked-input/__test__/index.test.tsx
@@ -67,7 +67,7 @@ describe('MaskedInput', () => {
     const { getByTestId } = render(<MaskedInput mask='___' inputRef={ref} />);
 
     expect(ref.current instanceof HTMLInputElement).toBe(true);
-    expect(getByTestId('base-input:field')).toBe(ref.current);
+    expect(getByTestId('base-input:field') === ref.current).toBe(true);
   });
 
   it('should handle "onBlur" prop', () => {
@@ -84,8 +84,8 @@ describe('MaskedInput', () => {
       <MaskedInput mask='____' value='22' onChange={jest.fn()} />,
     );
 
-    expect(getByTestId('rest-placeholder-shift')).toBe('22');
-    expect(getByTestId('rest-placeholder')).toBe('__');
+    expect(getByTestId('rest-placeholder-shift').textContent).toBe('22');
+    expect(getByTestId('rest-placeholder').textContent).toBe('__');
 
     rerender(
       <MaskedInput

--- a/src/masked-input/__test__/index.test.tsx
+++ b/src/masked-input/__test__/index.test.tsx
@@ -80,11 +80,12 @@ describe('MaskedInput', () => {
   });
 
   it('should handle "baseInputProps.restPlaceholder" prop', () => {
-    const { container, rerender } = render(
+    const { rerender, getByTestId, queryAllByTestId } = render(
       <MaskedInput mask='____' value='22' onChange={jest.fn()} />,
     );
 
-    expect(container.querySelector('.rest-placeholder')?.textContent).toBe('22__');
+    expect(getByTestId('rest-placeholder-shift')).toBe('22');
+    expect(getByTestId('rest-placeholder')).toBe('__');
 
     rerender(
       <MaskedInput
@@ -97,6 +98,7 @@ describe('MaskedInput', () => {
       />,
     );
 
-    expect(container.querySelector('.rest-placeholder')?.textContent).toBe('');
+    expect(queryAllByTestId('rest-placeholder-shift')).toHaveLength(0);
+    expect(queryAllByTestId('rest-placeholder')).toHaveLength(0);
   });
 });

--- a/src/phone-input/__stories__/index.stories.tsx
+++ b/src/phone-input/__stories__/index.stories.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { PhoneInput } from '..';
+import { TextButton } from '../../text-button';
+
+export default {
+  title: 'common/PhoneInput',
+  component: PhoneInput,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export function Primary() {
+  const defaultValue = '79998887766';
+  const [key, setKey] = useState<number>(0);
+  const [value, setValue] = useState<string>(defaultValue);
+
+  return (
+    <>
+      <PhoneInput
+        key={key}
+        value={value}
+        onChange={(event, data) => {
+          setValue(data.cleanValue);
+        }}
+        style={{ width: '320px' }}
+      />
+
+      <p data-testid='phone:clean-value'>Значение: {value || '[пусто]'}</p>
+
+      <TextButton
+        size='s'
+        data-testid='phone:reset'
+        onClick={() => {
+          setKey(n => n + 1);
+          setValue(defaultValue);
+        }}
+      >
+        Сбросить
+      </TextButton>
+    </>
+  );
+}
+
+Primary.storyName = 'Простой пример';
+
+export function Validation() {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <PhoneInput
+      style={{ width: 320 }}
+      value={value}
+      onFocus={() => {
+        setError(null);
+      }}
+      onChange={(event, data) => {
+        setValue(data.cleanValue);
+        setError(null);
+      }}
+      onBlur={(event, data) => {
+        !data.completed && setError('Поле не заполнено');
+      }}
+      failed={Boolean(error)}
+      caption={error || 'Мы не будем звонить по этому номеру'}
+    />
+  );
+}
+
+Validation.storyName = 'Пример: проверка заполнения';
+
+export function DefineCountryMask() {
+  return (
+    <>
+      <article>
+        <h3>Пустое значение - «Россия» по умолчанию</h3>
+        <PhoneInput style={{ width: 320 }} defaultValue='' />
+      </article>
+      <article>
+        <h3>Армения</h3>
+        <PhoneInput style={{ width: 320 }} defaultValue='37422333444' />
+      </article>
+      <article>
+        <h3>Грузия</h3>
+        <PhoneInput style={{ width: 320 }} defaultValue='995111222333' />
+      </article>
+      <article>
+        <h3>Узбекистан</h3>
+        <PhoneInput style={{ width: 320 }} defaultValue='998556667777' />
+      </article>
+      <article>
+        <h3>Неизвестный номер - «Другое»</h3>
+        <PhoneInput style={{ width: 320 }} defaultValue='1234567890' />
+      </article>
+    </>
+  );
+}
+
+DefineCountryMask.storyName = 'Пример: определение маски';
+
+export function NativeNumberInputComparison() {
+  // PhoneInput
+  const defaultValue = '79501922700';
+  const [value, setValue] = useState<string>(defaultValue);
+  const [key, setKey] = useState<number>(0);
+
+  // input[type=number]
+  const defaultText = 'Hello';
+  const [text, setText] = useState<string>(defaultText);
+
+  return (
+    <>
+      <PhoneInput
+        key={key}
+        value={value}
+        onChange={(event, data) => {
+          setValue(data.cleanValue);
+        }}
+        style={{ width: '320px' }}
+      />
+
+      <p>Значение: {value || '[пусто]'}</p>
+
+      <TextButton
+        size='s'
+        onClick={() => {
+          setValue(defaultValue);
+          setKey(n => n + 1);
+        }}
+      >
+        Сбросить
+      </TextButton>
+
+      <p>
+        {/* Firefox позволяет вводить в input[type=number] нечисловые значения */}
+        <input
+          type='number'
+          value={text}
+          onChange={event => {
+            setText(event.target.value);
+          }}
+        />
+      </p>
+
+      <p>Значение: {text || '[пусто]'}</p>
+
+      <TextButton
+        size='s'
+        onClick={() => {
+          setText(defaultText);
+        }}
+      >
+        Сбросить
+      </TextButton>
+    </>
+  );
+}
+
+NativeNumberInputComparison.storyName = 'Тест: сравнение с input[type=number]';

--- a/src/phone-input/__test__/index.test.tsx
+++ b/src/phone-input/__test__/index.test.tsx
@@ -1,0 +1,144 @@
+import React, { ChangeEvent, createRef } from 'react';
+import {
+  createEvent,
+  fireEvent,
+  getAllByTestId,
+  getByTestId,
+  queryAllByTestId,
+  render,
+} from '@testing-library/react';
+import { PhoneInput } from '..';
+import { MaskData } from '../../masked-input';
+
+describe('PhoneInput', () => {
+  it('render input with opener and russia mask by default', () => {
+    const { container } = render(<PhoneInput value='' onChange={jest.fn()} />);
+
+    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
+    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('+7 (');
+    expect(getByTestId(container, 'rest-placeholder-shift').textContent).toBe('+7 (');
+    expect(getByTestId(container, 'rest-placeholder').textContent).toBe('___) ___-__-__');
+    expect(getByTestId(container, 'field-block:label').textContent).toBe('Телефон');
+  });
+
+  it('handle "defaultValue" prop properly', () => {
+    const expected = '+7 (999) 888-77-66';
+
+    const { container, rerender } = render(<PhoneInput defaultValue='79998887766' />);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
+
+    rerender(<PhoneInput defaultValue='71112223344' />);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
+  });
+
+  it('open/close menu by opener click', () => {
+    const { baseElement, container } = render(<PhoneInput value='' onChange={jest.fn()} />);
+
+    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
+    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+  });
+
+  it('reset value and change mask by select item from menu', () => {
+    const onChange = jest.fn((event: ChangeEvent, data: MaskData) => void [event, data]);
+
+    const { baseElement, container } = render(
+      <PhoneInput defaultValue='998-22-333-4444' onChange={onChange} />,
+    );
+
+    // open menu
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(13);
+    expect(onChange).toBeCalledTimes(0);
+
+    // select georgia
+    fireEvent.click(queryAllByTestId(baseElement, 'dropdown-item')[6]);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(0);
+    expect(onChange).toBeCalledTimes(1);
+    expect(onChange.mock.calls[0][1].value).toBe('+995 (');
+    expect(onChange.mock.calls[0][1].cleanValue).toBe('995');
+  });
+
+  it('field must be looks like focused when opener focused or menu opened', () => {
+    const { baseElement, container } = render(<PhoneInput defaultValue='998-22-333-4444' />);
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+
+    fireEvent.focus(getByTestId(container, 'base-input:field'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+
+    fireEvent.blur(getByTestId(container, 'base-input:field'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+
+    fireEvent.focus(getByTestId(container, 'phone-input:menu-opener'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+
+    fireEvent.blur(getByTestId(container, 'phone-input:menu-opener'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+    expect(document.activeElement).toBe(getByTestId(baseElement, 'dropdown'));
+
+    fireEvent.blur(getByTestId(baseElement, 'dropdown'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+  });
+
+  it('should not show rest placeholder for "other" variant', () => {
+    const { container } = render(<PhoneInput defaultValue='1234567890' />);
+
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('1234567890');
+    expect(queryAllByTestId(container, 'rest-placeholder-shift')).toHaveLength(0);
+    expect(queryAllByTestId(container, 'rest-placeholder')).toHaveLength(0);
+  });
+
+  it('should handle "inputRef" prop', () => {
+    const inputRef = createRef<HTMLInputElement>();
+    expect(inputRef.current).toBe(null);
+
+    const { container } = render(<PhoneInput inputRef={inputRef} />);
+    expect(inputRef.current instanceof HTMLInputElement).toBe(true);
+    expect(inputRef.current === getByTestId(container, 'base-input:field')).toBe(true);
+  });
+
+  it('should handle "blockRef" prop', () => {
+    const blockRef = createRef<HTMLDivElement>();
+    expect(blockRef.current).toBe(null);
+
+    const { container } = render(<PhoneInput blockRef={blockRef} />);
+    expect(blockRef.current instanceof HTMLDivElement).toBe(true);
+    expect(blockRef.current === getByTestId(container, 'field-block:block')).toBe(true);
+  });
+
+  it('should prevent default of dropdown item mousedown event', () => {
+    const { baseElement, container } = render(<PhoneInput />);
+
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(13);
+
+    const menuItem = getAllByTestId(baseElement, 'dropdown-item')[2];
+    const event = createEvent.mouseDown(menuItem);
+    fireEvent(menuItem, event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should handle change event of masked input properly', () => {
+    const onChange = jest.fn();
+    const { container } = render(<PhoneInput onChange={onChange} />);
+
+    expect(onChange).toBeCalledTimes(0);
+    fireEvent.focus(getByTestId(container, 'base-input:field'));
+    fireEvent.change(getByTestId(container, 'base-input:field'), {
+      target: { value: '79992225511' },
+    });
+    expect(onChange).toBeCalledTimes(1);
+  });
+});

--- a/src/phone-input/__test__/utils.test.ts
+++ b/src/phone-input/__test__/utils.test.ts
@@ -1,5 +1,5 @@
 import { IDS } from '../presets';
-import { defineCountry } from '../utils';
+import { defineCountry, stubSyntheticEvent } from '../utils';
 
 describe('defineCountry', () => {
   it('should define countries', () => {
@@ -10,5 +10,22 @@ describe('defineCountry', () => {
     ].forEach(({ value, countryId }) => {
       expect(defineCountry(value).id).toBe(countryId);
     });
+  });
+});
+
+describe('stubSyntheticEvent', () => {
+  it('should return event with methods', () => {
+    const event = stubSyntheticEvent(document.createElement('div'), new Event('test'));
+
+    expect(() => {
+      event.persist();
+      event.preventDefault();
+      event.stopPropagation();
+      event.persist();
+    }).not.toThrow();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(event.isDefaultPrevented()).toBe(false);
+    expect(event.isPropagationStopped()).toBe(false);
   });
 });

--- a/src/phone-input/index.tsx
+++ b/src/phone-input/index.tsx
@@ -1,0 +1,5 @@
+import { PhoneInputProps } from './types';
+import { PhoneInput } from './phone-input';
+
+export type { PhoneInputProps };
+export { PhoneInput };

--- a/src/phone-input/phone-input.module.scss
+++ b/src/phone-input/phone-input.module.scss
@@ -1,0 +1,22 @@
+@use '../colors';
+
+.opener {
+  display: flex;
+  align-items: center;
+  user-select: none;
+  cursor: pointer;
+  padding: 8px;
+  margin: -8px;
+  border-radius: 4px;
+  &:focus-visible {
+    outline: 0;
+    background: colors.$additional-sky;
+  }
+}
+
+.arrow {
+  display: block;
+  fill: colors.$basic-gray38;
+  margin-left: 4px;
+  pointer-events: none; // игнорируем клики т.к. после них элемент стрелки подменяется и считается что он сработал вне элемента родителя
+}

--- a/src/phone-input/phone-input.tsx
+++ b/src/phone-input/phone-input.tsx
@@ -1,0 +1,206 @@
+import React, { useCallback, useContext, useImperativeHandle, useRef, useState } from 'react';
+import { PhoneInputProps } from './types';
+import { DropdownItem } from '../dropdown-item';
+import { useIsomorphicLayoutEffect } from '../hooks';
+import { MaskData, MaskedInput, MaskedInputProps } from '../masked-input';
+import { countriesList, Country, IDS } from './presets';
+import { defineCountry, PhoneValue, stubSyntheticEvent } from './utils';
+import { Select } from '../select';
+import { SelectContext } from '../select/utils';
+import UpSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/Arrows/up';
+import DownSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/Arrows/down';
+import classNames from 'classnames/bind';
+import styles from './phone-input.module.scss';
+
+const cx = classNames.bind(styles);
+
+/**
+ * Поле ввода номера телефона.
+ * @param props Свойства.
+ * @return Элемент.
+ */
+export function PhoneInput({
+  value,
+  defaultValue,
+  label = 'Телефон',
+  inputRef: inputRefProp,
+  blockRef: blockRefProp,
+  onBlur,
+  onChange,
+  onFocus,
+  onCountrySelect,
+  'data-testid': testId = 'phone-input',
+  ...props
+}: PhoneInputProps) {
+  const firstRenderRef = useRef(true);
+
+  const [initialValue] = useState<string>(value ?? defaultValue ?? '');
+  const [country, setCountry] = useState<Country>(() => defineCountry(initialValue));
+  const [cleanValue, setCleanValue] = useState<string>(() =>
+    PhoneValue.removeCode(initialValue, country),
+  );
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+    inputRefProp,
+    () => inputRef.current,
+  );
+
+  const blockRef = useRef<HTMLDivElement>(null);
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+    blockRefProp,
+    () => blockRef.current,
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (typeof value !== 'undefined') {
+      setCleanValue(PhoneValue.removeCode(value, country));
+    }
+  }, [value]);
+
+  const dispatchCountryChange = useCallback(
+    (input: HTMLInputElement) => {
+      const nativeEvent = new Event('input');
+      const syntheticEvent = stubSyntheticEvent(input, nativeEvent);
+
+      // @todo перенести вызов onChange в callback onValueChange если будет необходим preventDefault() и тд
+      onChange?.(syntheticEvent, {
+        value: input.value,
+        cleanValue: PhoneValue.addCode('', country),
+        completed: false,
+      });
+
+      onCountrySelect?.(country);
+    },
+    [onChange, onCountrySelect, country],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    if (!firstRenderRef.current) {
+      inputRef.current && dispatchCountryChange(inputRef.current);
+    }
+  }, [country]);
+
+  useIsomorphicLayoutEffect(() => {
+    firstRenderRef.current = false;
+  }, []);
+
+  const processData = useCallback(
+    (data: MaskData): MaskData => ({
+      ...data,
+      completed: data.completed || country.id === IDS.other,
+      cleanValue: PhoneValue.addCode(data.cleanValue, country),
+    }),
+    [country],
+  );
+
+  const changeCountry = useCallback((selected: Country) => {
+    setCountry(selected);
+    setCleanValue('');
+  }, []);
+
+  return (
+    <Select
+      opener={
+        <PhoneMaskedInput
+          {...props}
+          data-testid={testId}
+          country={country}
+          inputRef={inputRef}
+          blockRef={blockRef}
+          label={label}
+          mask={country.mask}
+          onFocus={(event, data) => {
+            onFocus?.(event, processData(data));
+          }}
+          onChange={(event, data) => {
+            onChange?.(event, processData(data));
+          }}
+          onBlur={(event, data) => {
+            onBlur?.(event, processData(data));
+          }}
+          value={cleanValue}
+        />
+      }
+      onValueChange={itemValue => {
+        const item = countriesList.find(c => c.id === itemValue);
+        item && changeCountry(item);
+      }}
+    >
+      {countriesList.map((item, index) => (
+        <DropdownItem
+          value={item.id}
+          key={index}
+          size='m'
+          role='menuitem'
+          onMouseDown={event => {
+            // ВАЖНО: клик по блоку поля вызывает фокус на поле и preventDefault()
+            // отменяем с помощью другого preventDefault()
+            event.preventDefault();
+          }}
+          selected={item.id === country.id}
+          startContent={<img alt='' width={24} height={24} src={item.imageSrc} />}
+          endContent={item.code}
+        >
+          {item.name}
+        </DropdownItem>
+      ))}
+    </Select>
+  );
+}
+
+/**
+ * Внутренний компонент, необходим для использования контекста SelectContext.
+ * @param props Свойства.
+ * @return Элемент.
+ */
+function PhoneMaskedInput({
+  country,
+  blockRef: blockRefProp,
+  ...props
+}: MaskedInputProps & { country: Country }) {
+  const select = useContext(SelectContext);
+  const blockRef = useRef<HTMLDivElement>(null);
+  const [openerFocused, setOpenerFocused] = useState(false);
+
+  useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+    blockRefProp,
+    () => blockRef.current,
+  );
+  useImperativeHandle<HTMLElement | null, HTMLDivElement | null>(
+    select.anchorRef,
+    () => blockRef.current,
+  );
+
+  const ArrowSVG = select.opened ? UpSVG : DownSVG;
+
+  return (
+    <MaskedInput
+      {...props}
+      // ВАЖНО: undefined нужен для поведения по умолчанию если меню скрыто и кнопка не в фокусе
+      focused={select.opened || openerFocused || undefined}
+      blockRef={blockRef}
+      baseInputProps={{
+        restPlaceholder: country.id === IDS.other ? '' : undefined,
+        ...props.baseInputProps,
+      }}
+      adornmentEnd={
+        <div
+          ref={select.openerRef as any}
+          tabIndex={0}
+          onFocus={() => setOpenerFocused(true)}
+          onBlur={() => setOpenerFocused(false)}
+          role='combobox'
+          aria-label='Выбор страны'
+          className={cx('opener')}
+          data-testid='phone-input:menu-opener'
+          onKeyDown={select.onKeyDown}
+          onMouseDown={select.onMouseDown}
+        >
+          <img alt='' width={24} height={24} src={country.imageSrc} />
+          <ArrowSVG className={styles.arrow} />
+        </div>
+      }
+    />
+  );
+}

--- a/src/phone-input/presets.ts
+++ b/src/phone-input/presets.ts
@@ -11,15 +11,14 @@ import turkmenistanPNG from './images/turkmenistan.png';
 import uzbekistanPNG from './images/uzbekistan.png';
 import ukrainePNG from './images/ukraine.png';
 import otherPNG from './images/other.png';
-import { keyBy } from 'lodash';
 
 export interface Country {
-  id: string;
-  name: string;
-  code: string;
-  codeChars: string;
-  mask: string;
-  imageSrc: string;
+  readonly id: string;
+  readonly name: string;
+  readonly code: string;
+  readonly codeChars: string;
+  readonly mask: string;
+  readonly imageSrc: string;
 }
 
 export const IDS = {
@@ -36,7 +35,7 @@ export const IDS = {
   uzbekistan: 'uzbekistan',
   ukraine: 'ukraine',
   other: 'other',
-};
+} as const;
 
 const NAMES = {
   [IDS.russia]: 'Россия',
@@ -52,7 +51,7 @@ const NAMES = {
   [IDS.uzbekistan]: 'Узбекистан',
   [IDS.ukraine]: 'Украина',
   [IDS.other]: 'Другое',
-};
+} as const;
 
 const MASKS = {
   [IDS.russia]: '+7 (___) ___-__-__',
@@ -68,7 +67,7 @@ const MASKS = {
   [IDS.uzbekistan]: '+998-__-___-____',
   [IDS.ukraine]: '+380 (__) ___-__-__',
   [IDS.other]: '_______________',
-};
+} as const;
 
 const IMAGES = {
   [IDS.russia]: russiaPNG,
@@ -84,7 +83,7 @@ const IMAGES = {
   [IDS.uzbekistan]: uzbekistanPNG,
   [IDS.ukraine]: ukrainePNG,
   [IDS.other]: otherPNG,
-};
+} as const;
 
 const CODES = {
   [IDS.russia]: '+7',
@@ -100,7 +99,7 @@ const CODES = {
   [IDS.uzbekistan]: '+998',
   [IDS.ukraine]: '+380',
   [IDS.other]: '',
-};
+} as const;
 
 const ORDER = [
   IDS.russia,
@@ -116,9 +115,9 @@ const ORDER = [
   IDS.uzbekistan,
   IDS.ukraine,
   IDS.other,
-];
+] as const;
 
-export const countriesList: Country[] = ORDER.map(id => ({
+export const countriesList: ReadonlyArray<Country> = ORDER.map(id => ({
   id,
   name: NAMES[id],
   code: CODES[id],
@@ -127,4 +126,7 @@ export const countriesList: Country[] = ORDER.map(id => ({
   imageSrc: IMAGES[id],
 }));
 
-export const countries = keyBy(countriesList, data => data.id);
+export const countries = countriesList.reduce<Readonly<Record<string, Country>>>(
+  (acc, item) => ({ ...acc, [item.id]: item }),
+  {},
+);

--- a/src/phone-input/types.ts
+++ b/src/phone-input/types.ts
@@ -1,0 +1,7 @@
+import { MaskedInputProps } from '../masked-input';
+import { Country } from './presets';
+
+export interface PhoneInputProps
+  extends Omit<MaskedInputProps, 'mask' | 'placeholder' | 'pattern'> {
+  onCountrySelect?: (country: Country) => void;
+}

--- a/src/phone-input/utils.ts
+++ b/src/phone-input/utils.ts
@@ -1,3 +1,4 @@
+import { SyntheticEvent } from 'react';
 import { countries, countriesList, Country, IDS } from './presets';
 
 /**
@@ -5,7 +6,7 @@ import { countries, countriesList, Country, IDS } from './presets';
  * @param value Значение.
  * @return Данные маски страны.
  */
-export const defineCountry = (value: string): Country => {
+export function defineCountry(value: string): Country {
   let result;
 
   if (value) {
@@ -17,4 +18,60 @@ export const defineCountry = (value: string): Country => {
   }
 
   return result || countries.russia;
-};
+}
+
+/**
+ * Утилиты для работы со строкой, представляющей номер телефона.
+ */
+export const PhoneValue = {
+  /**
+   * Получив номер без кода страны и страну вернет номер с кодом.
+   * @param value Номер.
+   * @param country Страна.
+   * @return Номер.
+   */
+  addCode(value: string, country: Country): string {
+    return `${country.codeChars}${value.replace(/\D/g, '')}`;
+  },
+
+  /**
+   * Получив номер с кодом страны и страну вернет номер без кода.
+   * @param value Номер.
+   * @param country Страна.
+   * @return Номер.
+   */
+  removeCode(value: string, country: Country): string {
+    return value.replace(/\D/g, '').slice(country.codeChars.length);
+  },
+} as const;
+
+/**
+ * Заглушка для вызова callback'ов которые ожидают SyntheticEvent.
+ * @param element Элемент.
+ * @param nativeEvent Событие.
+ * @return Синтетическое событие.
+ */
+export function stubSyntheticEvent<T extends Element, E extends Event>(
+  element: T,
+  nativeEvent: E,
+): SyntheticEvent<T, E> & { target: EventTarget & T } {
+  return {
+    nativeEvent,
+    currentTarget: element,
+    target: element,
+    type: nativeEvent.type,
+    bubbles: nativeEvent.bubbles,
+    cancelable: nativeEvent.cancelable,
+    eventPhase: nativeEvent.eventPhase,
+    isTrusted: nativeEvent.isTrusted,
+    timeStamp: nativeEvent.timeStamp,
+
+    defaultPrevented: false,
+    isDefaultPrevented: () => false,
+    isPropagationStopped: () => false,
+
+    persist: () => void 0,
+    preventDefault: () => void 0,
+    stopPropagation: () => void 0,
+  };
+}

--- a/src/upload-area/__test__/index.test.tsx
+++ b/src/upload-area/__test__/index.test.tsx
@@ -67,17 +67,27 @@ describe('UploadArea', () => {
   });
 
   it('should handle focus/blur/click/keydown events on root element', () => {
-    const { getByTestId, rerender } = render(<UploadArea />);
+    const blurSpy = jest.fn();
+    const focusSpy = jest.fn();
+    const { getByTestId, rerender } = render(
+      <UploadArea rootProps={{ onFocus: focusSpy, onBlur: blurSpy }} />,
+    );
     const root = getByTestId('upload-area');
     const input = getByTestId('upload-area:input');
     const clickSpy = jest.spyOn(input, 'click');
 
     expect(root.classList.contains('active')).toBe(false);
+    expect(focusSpy).toBeCalledTimes(0);
+    expect(blurSpy).toBeCalledTimes(0);
 
     fireEvent.focus(root);
-    expect(root.classList.contains('active')).toBe(true);
+    expect(root.classList.contains('active')).toBe(false);
+    expect(focusSpy).toBeCalledTimes(1);
+    expect(blurSpy).toBeCalledTimes(0);
 
     fireEvent.blur(root);
+    expect(focusSpy).toBeCalledTimes(1);
+    expect(blurSpy).toBeCalledTimes(1);
     expect(root.classList.contains('active')).toBe(false);
 
     expect(clickSpy).toBeCalledTimes(0);

--- a/src/upload-area/upload-area.module.scss
+++ b/src/upload-area/upload-area.module.scss
@@ -24,7 +24,8 @@
     cursor: pointer;
     border-color: colors.$basic-blue;
   }
-  &:not(.disabled).active {
+  &:not(.disabled).active,
+  &:not(.disabled):focus-visible {
     border-color: colors.$basic-blue;
     border-style: solid;
   }

--- a/src/upload-area/upload-area.tsx
+++ b/src/upload-area/upload-area.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, useCallback, useRef, useState } from 'react';
+import React, { ChangeEventHandler, useCallback, useRef } from 'react';
 import { Link } from '../link';
 import { useFilesDrop } from './utils';
 import { upperFirst } from 'lodash';
@@ -31,7 +31,6 @@ export function UploadArea({
   inputProps,
   'data-testid': testId = 'upload-area',
 }: UploadAreaProps) {
-  const [focused, setFocused] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const secondaryInfo: string = upperFirst(
@@ -78,7 +77,7 @@ export function UploadArea({
   const rootClassName = cx(
     'root',
     size !== 'unset' && `size-${size}`,
-    { active: active || focused, failed, disabled },
+    { active, failed, disabled },
     className,
   );
 
@@ -93,7 +92,6 @@ export function UploadArea({
       role='button'
       onFocus={event => {
         if (!disabled) {
-          setFocused(true);
           rootProps?.onFocus?.(event);
         }
       }}
@@ -111,7 +109,6 @@ export function UploadArea({
         }
       }}
       onBlur={event => {
-        setFocused(false);
         rootProps?.onBlur?.(event);
       }}
     >


### PR DESCRIPTION
- base-input: rest-placeholder теперь можно найти по data-testid
- base-input: теперь не выводит элемент rest-placeholder если value пустое
- masked-input: убраны костыли с ref'ами
- phone-input: добавлена новая реализация компонента PhoneInput
- мелкие доработки конфига pw
- upload-area: обводка solid теперь только при фокусе клавиатурой (убрана после клика)