### PR TITLE
#350 Popup: убрать автовыделение крестика в браузере Safari #350 

### DIFF
--- a/src/popup/__test__/index.test.tsx
+++ b/src/popup/__test__/index.test.tsx
@@ -161,6 +161,9 @@ describe('useFocusTrap', () => {
       <TestComponent afterDeactivate={() => spy.dispatchEvent(new Event('test-event'))} />,
     );
 
+    await findByText('Focused: nothing');
+    await user.keyboard('[Tab]');
+
     await findByText('Focused: name');
     expect(document.activeElement).toBe(getByTestId('name'));
 

--- a/src/popup/utils.ts
+++ b/src/popup/utils.ts
@@ -100,13 +100,18 @@ export function useFocusTrap(
         allowOutsideClick: true,
         tabbableOptions: { displayCheck: 'none' },
         onPostDeactivate: afterDeactivateRef.current,
-        fallbackFocus: element,
+
+        // ВАЖНО: отключаем тк в противном случае в Safari срабатывает :focus-visible
+        initialFocus: false,
       });
 
       trap.activate();
 
       return () => {
-        trap.deactivate({ returnFocus: true });
+        trap.deactivate({
+          // @todo тоже убрать?
+          returnFocus: true,
+        });
       };
     }
   }, [ref, enabled]);

--- a/src/range/index.tsx
+++ b/src/range/index.tsx
@@ -1,14 +1,13 @@
 import { Component, createRef } from 'react';
-import withPrevent from '../helpers/with-prevent';
-import boundsOf from '../helpers/bounds-of';
-import createContainer, { Container } from '../helpers/create-container';
+import { boundsOf } from '../helpers/bounds-of';
+import { createContainer, Container } from '../helpers/create-container';
 import { getEventClientPos } from '../helpers/events';
-import centerOf from '../helpers/center-of';
-import on from '../helpers/on';
+import { centerOf } from '../helpers/center-of';
+import { on } from '../helpers/on';
 import { getFractionDepth } from '../helpers/get-fraction-depth';
 import { isInteger, clamp } from 'lodash';
 import classnames from 'classnames/bind';
-import classes from './range.module.scss';
+import styles from './range.module.scss';
 
 interface CallbackData {
   startValue: number;
@@ -44,7 +43,7 @@ export interface RangeProps {
   wrapperProps?: React.HTMLAttributes<HTMLDivElement>;
 }
 
-const cx = classnames.bind(classes);
+const cx = classnames.bind(styles);
 
 /**
  * Возвращает долю от диапазона, заданную числом.
@@ -103,7 +102,7 @@ export class Range extends Component<RangeProps> {
 
     this.updateValues = this.updateValues.bind(this);
     this.handleDragEnd = this.handleDragEnd.bind(this);
-    this.handleDragStart = withPrevent(this.handleDragStart.bind(this));
+    this.handleDragStart = this.handleDragStart.bind(this);
   }
 
   /** @inheritdoc */
@@ -150,6 +149,9 @@ export class Range extends Component<RangeProps> {
    * @param event Событие.
    */
   handleDragStart(event: MouseEvent | TouchEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (!this.props.disabled) {
       this.updateActiveThumb(event);
       this.toggleGrabbed(true);


### PR DESCRIPTION
- popup: убран фокус на крестике при открытии (в Safari срабатывает :focus-visible)
- range: удален withPrevent, мелкие правки стиля кода

Closes #350