### PR TITLE
Шаг 1 #358 Отключить injectGlobals в Jest

### DIFF
--- a/src/_internal/dropdown-loading/index.tsx
+++ b/src/_internal/dropdown-loading/index.tsx
@@ -8,6 +8,7 @@ type DropdownLoadingProps = Omit<HTMLAttributes<HTMLDivElement>, 'className' | '
  * Плашка состояния загрузки для Dropdown.
  * @param props Свойства.
  * @return Элемент.
+ * @todo Перенести в ./dropdown.
  */
 export function DropdownLoading(props: DropdownLoadingProps) {
   return (

--- a/src/arrow-button/index.tsx
+++ b/src/arrow-button/index.tsx
@@ -1,5 +1,4 @@
-import classnames from 'classnames/bind';
-import classes from './arrow-button.module.scss';
+import type { ElementType, SVGAttributes } from 'react';
 import UpSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/ArrowUp';
 import RightSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/ArrowRight';
 import DownSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/ArrowDown';
@@ -8,14 +7,14 @@ import UpSmallSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/ArrowUp';
 import RightSmallSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/ArrowRight';
 import DownSmallSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/ArrowDown';
 import LeftSmallSVG from '@sima-land/ui-quarks/icons/16x16/Stroked/ArrowLeft';
+import classNames from 'classnames/bind';
+import styles from './arrow-button.module.scss';
 
 export type ArrowButtonSize = 's' | 'l';
 
 export type ArrowDirection = 'up' | 'right' | 'down' | 'left';
 
-type IconSet = Readonly<
-  Record<ArrowDirection, React.ComponentType<React.SVGAttributes<SVGSVGElement>>>
->;
+type IconSet = Readonly<Record<ArrowDirection, ElementType<SVGAttributes<SVGSVGElement>>>>;
 
 export interface ArrowButtonProps
   extends Omit<JSX.IntrinsicElements['button'], 'size' | 'children'> {
@@ -29,7 +28,7 @@ export interface ArrowButtonProps
   'data-testid'?: string;
 }
 
-const cx = classnames.bind(classes);
+const cx = classNames.bind(styles);
 
 const ICONS: Readonly<Record<ArrowButtonSize, IconSet>> = {
   s: {

--- a/src/base-input/types.ts
+++ b/src/base-input/types.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, Ref, TextareaHTMLAttributes } from 'react';
+import { CSSProperties, InputHTMLAttributes, Ref, TextareaHTMLAttributes } from 'react';
 
 export interface RestPlaceholderDefinition {
   /** Текст placeholder'а. */
@@ -8,7 +8,7 @@ export interface RestPlaceholderDefinition {
   shiftValue?: string;
 }
 
-export interface BaseInputStyle extends React.CSSProperties {
+export interface BaseInputStyle extends CSSProperties {
   '--placeholder-color'?: string;
 }
 

--- a/src/dropdown/index.tsx
+++ b/src/dropdown/index.tsx
@@ -1,15 +1,15 @@
-import { forwardRef } from 'react';
+import { CSSProperties, HTMLAttributes, forwardRef } from 'react';
 import { BoxShadow } from '../styling/shadows';
 import { MediumRounds } from '../styling/shapes';
 import { CustomScrollbar, CustomScrollbarProps } from '../_internal/custom-scrollbar';
 import classnames from 'classnames/bind';
 import styles from './dropdown.module.scss';
 
-interface DropdownStyle extends React.CSSProperties {
+interface DropdownStyle extends CSSProperties {
   '--dropdown-max-height'?: string;
 }
 
-export interface DropdownProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'style'> {
+export interface DropdownProps extends Omit<HTMLAttributes<HTMLDivElement>, 'style'> {
   /** Стили. */
   style?: DropdownStyle;
 

--- a/src/helpers/point.ts
+++ b/src/helpers/point.ts
@@ -17,3 +17,5 @@ export function Point(x = 0, y = 0): IPoint {
  * @deprecated Следует использовать именованный экспорт. Экспорт по умолчанию будет удалён в будущем.
  */
 export default Point;
+
+// @todo перенести в math?

--- a/src/hint/utils.ts
+++ b/src/hint/utils.ts
@@ -228,18 +228,18 @@ export function useTempHintState(
   { timeout = 3000 }: { timeout?: number } = {},
 ) {
   const [open, setOpen] = useState<boolean>(initialState);
-  const timerRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const updateTimer = useCallback(
     (value: boolean): void => {
       // сбрасываем предыдущий таймер если был
       if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current);
+        clearTimeout(timerRef.current);
       }
 
       // запускаем новый таймер если надо
       if (value) {
-        timerRef.current = window.setTimeout(() => setOpen(false), timeout);
+        timerRef.current = setTimeout(() => setOpen(false), timeout);
       }
     },
     [timeout],

--- a/src/layout/__test__/__snapshots__/index.test.tsx.snap
+++ b/src/layout/__test__/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Layout should handle "disabledOn" prop 1`] = `
 exports[`Layout should renders correctly 1`] = `
 <div>
   <div
-    class="layout test-class "
+    class="layout test-class"
     style="height: 128px;"
   >
     Hello, world!

--- a/src/layout/layout.module.scss
+++ b/src/layout/layout.module.scss
@@ -1,56 +1,87 @@
 @use '../breakpoints';
 
+@mixin layout {
+  // ВАЖНО: не используем 100vw так как при использовании 100vw не вычитается ширина полосы прокрутки страницы
+  width: 100%;
+
+  // центрируем
+  margin-left: auto;
+  margin-right: auto;
+}
+
+// ВАЖНО: не прокидываем никаких кастомных свойств внутрь чтобы ими не воспользовались
 .layout {
-  @each $key, $val in breakpoints.$map {
-    @include breakpoints.up($key) {
-      &.disabled-#{$key} {
-        width: auto;
-        max-width: none;
-        padding-left: 0;
-        padding-right: 0;
-        margin-left: 0;
-        margin-right: 0;
-      }
-      &:not(.disabled-#{$key}) {
-        // ВАЖНО: не используем 100vw так как при использовании 100vw не вычитается ширина полосы прокрутки страницы
-        width: 100%;
-        max-width: var(--layout-fixed-width);
-        margin-left: auto;
-        margin-right: auto;
-        padding-left: var(--layout-fluid-gutter);
-        padding-right: var(--layout-fluid-gutter);
+  @include breakpoints.down('ms') {
+    &:not(.disabled-mxs) {
+      @include layout;
+      padding-left: 16px;
+      padding-right: 16px;
+    }
+  }
+  @include breakpoints.up('ms') {
+    @include breakpoints.down('mm') {
+      &:not(.disabled-ms) {
+        @include layout;
+        padding-left: 16px;
+        padding-right: 16px;
       }
     }
   }
-  @include breakpoints.up('mxs') {
-    --layout-fixed-width: initial;
-    --layout-fluid-gutter: 16px;
-  }
   @include breakpoints.up('mm') {
-    --layout-fixed-width: 656px;
-    --layout-fluid-gutter: initial;
+    @include breakpoints.down('ml') {
+      &:not(.disabled-mm) {
+        @include layout;
+        max-width: 656px;
+      }
+    }
   }
   @include breakpoints.up('ml') {
-    --layout-fixed-width: 672px;
-    --layout-fluid-gutter: initial;
+    @include breakpoints.down('xs') {
+      &:not(.disabled-ml) {
+        @include layout;
+        max-width: 672px;
+      }
+    }
   }
   @include breakpoints.up('xs') {
-    --layout-fixed-width: initial;
-    --layout-fluid-gutter: 64px;
+    @include breakpoints.down('s') {
+      &:not(.disabled-xs) {
+        @include layout;
+        padding-left: 64px;
+        padding-right: 64px;
+      }
+    }
+  }
+  @include breakpoints.up('s') {
+    @include breakpoints.down('m') {
+      &:not(.disabled-s) {
+        @include layout;
+        padding-left: 64px;
+        padding-right: 64px;
+      }
+    }
+  }
+  @include breakpoints.up('m') {
+    @include breakpoints.down('l') {
+      &:not(.disabled-m) {
+        @include layout;
+        padding-left: 64px;
+        padding-right: 64px;
+      }
+    }
   }
   @include breakpoints.up('l') {
-    --layout-fixed-width: 1472px;
-    --layout-fluid-gutter: initial;
+    @include breakpoints.down('xl') {
+      &:not(.disabled-l) {
+        @include layout;
+        max-width: 1472px;
+      }
+    }
   }
   @include breakpoints.up('xl') {
-    --layout-fixed-width: 1504px;
-    --layout-fluid-gutter: initial;
-  }
-
-  // пока что не даём использовать приватные переменные чтобы не раскрывать принцип работы
-  // так как он может измениться
-  *:not(.layout) {
-    --layout-fixed-width: initial;
-    --layout-fluid-gutter: initial;
+    &:not(.disabled-xl) {
+      @include layout;
+      max-width: 1504px;
+    }
   }
 }

--- a/src/layout/layout.tsx
+++ b/src/layout/layout.tsx
@@ -19,8 +19,8 @@ export function Layout({
 }: Omit<LayoutProps, 'element'> & { rootRef?: Ref<HTMLDivElement> }) {
   const rootClassName = cx(
     'layout',
+    disabledOn.length > 0 && disabledOn.map(key => `disabled-${key}`),
     className,
-    disabledOn.map(key => `disabled-${key}`),
   );
 
   return (


### PR DESCRIPTION
- мелкие todo (patch)
- мелкие правки типов (удалено использование глобального неймспейса React) (patch)
- layout: теперь не используются css-переменные (patch)