### PR TITLE
Шаг 1 #392 Удалить deprecated- компоненты и утилиты

### DIFF
--- a/src/carousel/__test__/index.test.tsx
+++ b/src/carousel/__test__/index.test.tsx
@@ -1,7 +1,7 @@
 import { Carousel } from '..';
-import DraggableEvent from '../helpers/draggable-event';
+import { DraggableEvent } from '../helpers/draggable-event';
 import classes from '../carousel.module.scss';
-import Point from '../../helpers/point';
+import { Point } from '../../helpers/point';
 import { act, fireEvent, render } from '@testing-library/react';
 import { createRef } from 'react';
 import { getTranslateStyle } from '../../helpers/styles';

--- a/src/carousel/carousel.tsx
+++ b/src/carousel/carousel.tsx
@@ -5,7 +5,7 @@ import { boundsOf } from '../helpers/bounds-of';
 import { Point, IPoint } from '../helpers/point';
 import { maxIndexOf } from '../helpers/max-index-of';
 import { getRelativePos } from '../helpers/get-relative-pos';
-import { findChildIndex } from '../helpers/find-child-element';
+import { findChildIndex } from '../helpers/find-child-index';
 import { ArrowButton, ArrowButtonProps } from '../arrow-button';
 import { DraggableEvent } from './helpers/draggable-event';
 import { isBrowser } from '../helpers/is-browser';

--- a/src/carousel/draggable.tsx
+++ b/src/carousel/draggable.tsx
@@ -15,9 +15,9 @@ import {
   getEventClientPos,
   EventWithPosition,
 } from '../helpers/events';
+import { on } from '../helpers/on';
 import classnames from 'classnames/bind';
-import classes from './draggable.module.scss';
-import on from '../helpers/on';
+import styles from './draggable.module.scss';
 
 export interface Control {
   isGrabbed: () => boolean;
@@ -42,7 +42,7 @@ export interface DraggableProps {
   children?: ReactNode;
 }
 
-const cx = classnames.bind(classes);
+const cx = classnames.bind(styles);
 
 const EVENT_NAMES = {
   move: ['mousemove', 'touchmove'],
@@ -341,8 +341,3 @@ export class Draggable extends Component<DraggableProps> {
     );
   }
 }
-
-/**
- * @deprecated Следует использовать именованный экспорт. Экспорт по умолчанию будет удалён в будущем.
- */
-export default Draggable;

--- a/src/carousel/helpers/__test__/draggable-event.test.ts
+++ b/src/carousel/helpers/__test__/draggable-event.test.ts
@@ -1,4 +1,4 @@
-import DraggableEvent from '../draggable-event';
+import { DraggableEvent } from '../draggable-event';
 
 describe('DraggableEvent', () => {
   it('should handle props', () => {

--- a/src/carousel/helpers/draggable-event.ts
+++ b/src/carousel/helpers/draggable-event.ts
@@ -32,8 +32,3 @@ export class DraggableEvent implements Data {
     this.prevented = true;
   }
 }
-
-/**
- * @deprecated Следует использовать именованный экспорт. Экспорт по умолчанию будет удалён в будущем.
- */
-export default DraggableEvent;

--- a/src/helpers/__test__/find-child-index.test.ts
+++ b/src/helpers/__test__/find-child-index.test.ts
@@ -1,6 +1,6 @@
-import findChildElement from '../find-child-element';
+import { findChildIndex } from '../find-child-index';
 
-describe('findChildElement()', () => {
+describe('findChildIndex()', () => {
   afterEach(() => {
     document.body.innerHTML = '';
   });
@@ -9,7 +9,7 @@ describe('findChildElement()', () => {
     document.body.append(div);
 
     expect(
-      findChildElement({
+      findChildIndex({
         target: div,
         isSuitable: undefined,
       }),
@@ -24,7 +24,7 @@ describe('findChildElement()', () => {
     document.body.append(div, sibling1, sibling2, sibling3, sibling4);
 
     expect(
-      findChildElement({
+      findChildIndex({
         target: document.body,
         isSuitable: sibling => sibling.tagName === 'SECTION',
       }),
@@ -39,7 +39,7 @@ describe('findChildElement()', () => {
     document.body.append(div, sibling1, sibling2, sibling3, sibling4);
 
     expect(
-      findChildElement({
+      findChildIndex({
         target: document.body,
         isSuitable: sibling => sibling.tagName !== 'FOOTER',
         needBreakLoop: passed => !passed,
@@ -55,7 +55,7 @@ describe('findChildElement()', () => {
     document.body.append(div, sibling1, sibling2, sibling3, sibling4);
 
     expect(
-      findChildElement({
+      findChildIndex({
         target: document.body,
         startIndex: 4,
         increment: -1,
@@ -72,7 +72,7 @@ describe('findChildElement()', () => {
     document.body.append(div, sibling1, sibling2, sibling3, sibling4);
 
     expect(
-      findChildElement({
+      findChildIndex({
         target: document.body,
         startIndex: 4,
         increment: -1,

--- a/src/helpers/find-child-index.ts
+++ b/src/helpers/find-child-index.ts
@@ -44,8 +44,3 @@ export function findChildIndex({
 
   return result;
 }
-
-/**
- * @deprecated Следует использовать именованный экспорт. Экспорт по умолчанию будет удалён в будущем.
- */
-export default findChildIndex;

--- a/src/hooks/breakpoint/index.tsx
+++ b/src/hooks/breakpoint/index.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
 import { useIsomorphicLayoutEffect } from '..';
-import isBrowser from '../../helpers/is-browser';
+import { isBrowser } from '../../helpers/is-browser';
 import { Registry } from './types';
 import { BreakpointQuery, createRegistry } from './utils';
 

--- a/src/stroked-svg/__stories__/index.stories.tsx
+++ b/src/stroked-svg/__stories__/index.stories.tsx
@@ -1,11 +1,12 @@
 import { StrokedSVG } from '@sima-land/ui-nucleons/stroked-svg';
-import { WithHint } from '../../with-hint';
 import Favorite from '@sima-land/ui-quarks/icons/24x24/Stroked/Favorite';
 import ArrowLeft from '@sima-land/ui-quarks/icons/24x24/Stroked/ArrowLeft';
 import Bag from '@sima-land/ui-quarks/icons/24x24/Stroked/Bag2';
 import ShareAndroid from '@sima-land/ui-quarks/icons/24x24/Stroked/ShareAndroid';
 import ShareIOs from '@sima-land/ui-quarks/icons/24x24/Stroked/ShareIOs';
 import QuickView2 from '@sima-land/ui-quarks/icons/24x24/Stroked/QuickView2';
+import { useState } from 'react';
+import { Hint, useHintFloating, useHintOnHover } from '@sima-land/ui-nucleons/hint';
 
 export default {
   title: 'service/StrokedSVG',
@@ -20,7 +21,7 @@ const icons = [Favorite, ArrowLeft, Bag, ShareAndroid, ShareIOs, QuickView2];
 
 export function Primary() {
   return (
-    <div style={{ padding: '32px', display: 'flex', justifyContent: 'space-around' }}>
+    <div style={{ display: 'flex', gap: '32px' }}>
       {icons.map((icon, index) => (
         <StrokedSVG key={index} component={icon} />
       ))}
@@ -30,21 +31,25 @@ export function Primary() {
 
 Primary.storyName = 'Простой пример';
 
-export function Hint() {
+export function WithHint() {
+  // состояние
+  const [open, setOpen] = useState<boolean>(false);
+
+  // позиционирование
+  const { refs, ...floating } = useHintFloating({ open, onOpenChange: setOpen });
+
+  // пользовательское взаимодействие
+  const { getReferenceProps, getFloatingProps } = useHintOnHover(floating);
+
   return (
-    <div style={{ padding: '32px' }}>
-      <WithHint hint='Добавить в избранное' direction='right'>
-        {(ref, toggle) => (
-          <StrokedSVG
-            component={Favorite}
-            ref={ref as any}
-            onMouseEnter={() => toggle(true)}
-            onMouseLeave={() => toggle(false)}
-          />
-        )}
-      </WithHint>
-    </div>
+    <>
+      <StrokedSVG {...getReferenceProps()} ref={refs.setReference} component={Favorite} />
+
+      <Hint open={open} hintRef={refs.setFloating} arrowRef={refs.setArrow} {...getFloatingProps()}>
+        Добавить в избранное
+      </Hint>
+    </>
   );
 }
 
-Hint.storyName = 'С хинтом';
+WithHint.storyName = 'С хинтом';

--- a/src/stroked-svg/stroked-svg.tsx
+++ b/src/stroked-svg/stroked-svg.tsx
@@ -17,11 +17,17 @@ export const StrokedSVG = forwardRef<HTMLDivElement, StrokedSVGProps>(
       stroke = COLORS.get('basic-gray4'),
       strokeWidth = 1,
       className,
+      'data-testid': testId,
       ...restProps
     },
     ref,
   ) => (
-    <div ref={ref} className={classNames(styles.root, className)} {...restProps}>
+    <div
+      ref={ref}
+      className={classNames(styles.root, className)}
+      data-testid={testId}
+      {...restProps}
+    >
       <Tag stroke={stroke} strokeWidth={`${strokeWidth * 2}px`} className={styles.stroke} />
       <Tag fill={fill} className={styles.svg} />
     </div>

--- a/src/stroked-svg/types.ts
+++ b/src/stroked-svg/types.ts
@@ -1,6 +1,9 @@
 import type { ElementType, HTMLAttributes, SVGAttributes } from 'react';
+import type { WithTestId } from '../types';
 
-export interface StrokedSVGProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+export interface StrokedSVGProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'>,
+    WithTestId {
   /** Компонент, выводящий svg-элемент. */
   component: ElementType<SVGAttributes<SVGSVGElement>>;
 

--- a/src/text-button/__stories__/index.stories.tsx
+++ b/src/text-button/__stories__/index.stories.tsx
@@ -78,6 +78,21 @@ export function IconEnd() {
 
 IconEnd.storyName = 'Иконка в конце';
 
+export function IconOnly() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+      <TextButton size='s'>
+        <ShareSVG fill='currentColor' />
+      </TextButton>
+      <TextButton size='m'>
+        <ShareAndroidSVG fill='currentColor' />
+      </TextButton>
+    </div>
+  );
+}
+
+IconOnly.storyName = 'Только иконка';
+
 export function DifferentStates() {
   const [size, setSize] = useState<TextButtonSize>('m');
   const [color, setColor] = useState<TextButtonColor>('basic-blue');

--- a/src/text-button/text-button.tsx
+++ b/src/text-button/text-button.tsx
@@ -27,9 +27,9 @@ export function TextButton({
 }: TextButtonProps) {
   const rooClassName = cx(
     'root',
-    `color-${color}`,
-    `size-${size}`,
-    `icon-gutter-${iconGutter}`,
+    color && color !== 'unset' && `color-${color}`,
+    size && size !== 'unset' && `size-${size}`,
+    typeof iconGutter === 'number' && `icon-gutter-${iconGutter}`,
     underline && 'underline',
     disabled && 'disabled',
     className,
@@ -46,19 +46,26 @@ export function TextButton({
   let result: ReactElement;
 
   switch (restProps.as) {
-    case 'anchor':
+    case 'anchor': {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { as, ...anchorProps } = restProps;
+
       result = (
-        <a {...restProps} ref={anchorRef} className={rooClassName} data-testid={testId}>
+        <a {...anchorProps} ref={anchorRef} className={rooClassName} data-testid={testId}>
           {content}
         </a>
       );
       break;
+    }
 
     case 'button':
-    default:
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { as, ...buttonProps } = restProps;
+
       result = (
         <button
-          {...restProps}
+          {...buttonProps}
           ref={buttonRef}
           className={rooClassName}
           disabled={disabled}
@@ -68,6 +75,7 @@ export function TextButton({
         </button>
       );
       break;
+    }
   }
 
   return result;

--- a/src/text-button/types.ts
+++ b/src/text-button/types.ts
@@ -1,6 +1,7 @@
 import type {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
+  CSSProperties,
   ComponentType,
   Ref,
   SVGAttributes,
@@ -12,12 +13,16 @@ export type TextButtonSize = 's' | 'm';
 
 export type TextButtonColor = LinkColor;
 
+export interface TextButtonStyle extends CSSProperties {
+  '--text-button-icon-gutter'?: string;
+}
+
 interface CommonProps extends WithTestId {
   /** Размер. */
-  size?: TextButtonSize;
+  size?: TextButtonSize | 'unset';
 
   /** Цвет. */
-  color?: TextButtonColor;
+  color?: TextButtonColor | 'unset';
 
   /** Иконка перед текстом. */
   startIcon?: ComponentType<SVGAttributes<SVGSVGElement>>;
@@ -38,7 +43,10 @@ interface CommonProps extends WithTestId {
   disabled?: boolean;
 
   /** Отступ от иконок. */
-  iconGutter?: 4 | 8;
+  iconGutter?: 4 | 8 | 'unset';
+
+  /** Стили. */
+  style?: TextButtonStyle;
 }
 
 export type TextButtonAsButtonProps = CommonProps &

--- a/src/with-hint/utils.ts
+++ b/src/with-hint/utils.ts
@@ -1,5 +1,5 @@
 import { getScrollParent } from '../helpers/get-scroll-parent';
-import on from '../helpers/on';
+import { on } from '../helpers/on';
 import { getOriginCorrection } from '../with-tooltip/utils';
 
 const SPACE = 4;

--- a/src/with-tooltip/__stories__/utils.tsx
+++ b/src/with-tooltip/__stories__/utils.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes, ReactNode, useEffect, useRef, useState } from 'react';
 import { WithTooltip } from '..';
-import boundsOf from '../../helpers/bounds-of';
-import on from '../../helpers/on';
+import { boundsOf } from '../../helpers/bounds-of';
+import { on } from '../../helpers/on';
 import { Link } from '../../link';
 
 export const SHORT_TEXT = 'Short tooltip text.';

--- a/src/with-tooltip/positioning-tooltip.tsx
+++ b/src/with-tooltip/positioning-tooltip.tsx
@@ -5,7 +5,7 @@ import { placeTooltip } from './utils';
 import { Tooltip } from '../tooltip';
 import { useLayer } from '../helpers/layer';
 import { useOutsideClick } from '../hooks';
-import on from '../helpers/on';
+import { on } from '../helpers/on';
 
 export interface PositioningTooltipProps {
   /** Содержимое. */

--- a/src/with-tooltip/utils.ts
+++ b/src/with-tooltip/utils.ts
@@ -1,4 +1,4 @@
-import boundsOf from '../helpers/bounds-of';
+import { boundsOf } from '../helpers/bounds-of';
 import { getScrollParent } from '../helpers/get-scroll-parent';
 import { findOffsetParent } from '../helpers/find-offset-parent';
 


### PR DESCRIPTION
- убрано использование default import'ов утилит (patch)
- `text-button`: добавлена возможность задать unset для size, color, iconGutter (minor)
- `stroked-svg`: добавлена возможность задать data-testid (minor)
- `helpers`: модуль find-child-element переименован в find-child-index (major)

