### PR TITLE
Шаг 1 #413 Добавить моки web API для удобного использования вместе с соответствующими контекстами

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "style-loader": "^3.3.1",
         "stylelint": "^15.9.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2",
+        "typescript": "^5.3.3",
         "webpack": "^5.75.0"
       },
       "engines": {
@@ -22693,9 +22693,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -40210,9 +40210,9 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "ufo": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "style-loader": "^3.3.1",
     "stylelint": "^15.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.3",
     "webpack": "^5.75.0"
   },
   "peerDependencies": {

--- a/src/avatar/utils.tsx
+++ b/src/avatar/utils.tsx
@@ -4,7 +4,7 @@ import PersonSVG from '@sima-land/ui-quarks/icons/24x24/Stroked/Person';
 import classNames from 'classnames';
 import styles from './utils.module.scss';
 
-const USER_AVATAR_COLOR_TOKENS: ReadonlyArray<string> = [
+const USER_AVATAR_COLORS: ReadonlyArray<string> = [
   '#eb8585',
   '#fda09b',
   '#f49bb1',
@@ -64,7 +64,7 @@ export function getUserAvatarColor(identity: string): string {
     total += identity.charCodeAt(i);
   }
 
-  const list = USER_AVATAR_COLOR_TOKENS;
+  const list = USER_AVATAR_COLORS;
   const hash = total % list.length;
 
   return list[hash];

--- a/src/context/__test__/index.test.tsx
+++ b/src/context/__test__/index.test.tsx
@@ -1,0 +1,101 @@
+import { useContext, useEffect } from 'react';
+import { MatchMediaContext, ResizeObserverContext, IntersectionObserverContext } from '..';
+import { render } from '@testing-library/react';
+
+describe('MatchMediaContext', () => {
+  it('should use global browser value by default', () => {
+    jest.spyOn(window, 'matchMedia');
+
+    const TestComponent = () => {
+      const { matchMedia } = useContext(MatchMediaContext);
+
+      useEffect(() => {
+        matchMedia('(max-width: 200px)');
+      });
+
+      return <>Hello</>;
+    };
+
+    expect(window.matchMedia).toHaveBeenCalledTimes(0);
+    render(<TestComponent />);
+    expect(window.matchMedia).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ResizeObserverContext', () => {
+  it('should use global browser value by default', () => {
+    const spy = jest.fn();
+
+    const resizeObserverDescriptor = Object.getOwnPropertyDescriptor(window, 'ResizeObserver');
+
+    Object.defineProperty(window, 'ResizeObserver', {
+      value: class ResizeObserverMock {
+        constructor() {
+          spy();
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    });
+
+    const TestComponent = () => {
+      const { createResizeObserver } = useContext(ResizeObserverContext);
+
+      useEffect(() => {
+        createResizeObserver(() => {});
+      });
+
+      return <>Hello</>;
+    };
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    render(<TestComponent />);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    if (resizeObserverDescriptor) {
+      Object.defineProperty(window, 'ResizeObserver', resizeObserverDescriptor);
+    }
+  });
+});
+
+describe('IntersectionObserverContext', () => {
+  it('should use global browser value by default', () => {
+    const spy = jest.fn();
+
+    const IntersectionObserverDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      'IntersectionObserver',
+    );
+
+    Object.defineProperty(window, 'IntersectionObserver', {
+      value: class IntersectionObserverMock {
+        constructor() {
+          spy();
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {}
+      },
+    });
+
+    const TestComponent = () => {
+      const { createIntersectionObserver } = useContext(IntersectionObserverContext);
+
+      useEffect(() => {
+        createIntersectionObserver(() => {});
+      });
+
+      return <>Hello</>;
+    };
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    render(<TestComponent />);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    if (IntersectionObserverDescriptor) {
+      Object.defineProperty(window, 'IntersectionObserver', IntersectionObserverDescriptor);
+    }
+  });
+});

--- a/src/hooks/use-intersection/__test__/test-utils.test.ts
+++ b/src/hooks/use-intersection/__test__/test-utils.test.ts
@@ -88,6 +88,12 @@ describe('IntersectionMock', () => {
 
     mock.restore();
   });
+
+  it('_unregisterObserver()', () => {
+    const mock = new IntersectionMock();
+
+    expect(() => mock._unregisterObserver(new FakeIntersectionObserver(() => {}))).not.toThrow();
+  });
 });
 
 describe('FakeIntersectionObserver', () => {
@@ -144,5 +150,11 @@ describe('createFakeEntry', () => {
     expect(entry.rootBounds).toBe(null);
     expect(entry.boundingClientRect).toBe(null);
     expect(entry.intersectionRect).toBe(null);
+  });
+
+  it('disconnect()', () => {
+    const fake = new FakeIntersectionObserver(() => {});
+
+    expect(() => fake.disconnect()).not.toThrow();
   });
 });

--- a/src/hooks/use-intersection/test-utils.ts
+++ b/src/hooks/use-intersection/test-utils.ts
@@ -1,5 +1,8 @@
 import { act } from 'react-dom/test-utils';
 
+/**
+ * @deprecated Следует использовать утилиты из @sima-land/ui-nucleons/test-utils.
+ */
 export type IntersectionObserverEntryBase = Omit<
   IntersectionObserverEntry,
   'time' | 'rootBounds' | 'boundingClientRect' | 'intersectionRect'
@@ -11,6 +14,7 @@ let intersectionMock: IntersectionMock | undefined;
  * Возвращает новый объект, частично реализующий IntersectionObserverEntry.
  * @param base Базовая информация.
  * @return Объект.
+ * @deprecated Следует использовать утилиты из @sima-land/ui-nucleons/test-utils.
  */
 export function createFakeEntry(base: IntersectionObserverEntryBase): IntersectionObserverEntry {
   const entry: IntersectionObserverEntry = {
@@ -45,6 +49,7 @@ export function createFakeEntry(base: IntersectionObserverEntryBase): Intersecti
 
 /**
  * Реализует интерфейс для управления состоянием пересечения элемента с область видимости.
+ * @deprecated Следует использовать утилиты из @sima-land/ui-nucleons/test-utils.
  */
 export class IntersectionMock {
   _original: typeof IntersectionObserver;
@@ -118,6 +123,7 @@ export class IntersectionMock {
 
 /**
  * Имитация IntersectionObserver.
+ * @deprecated Следует использовать утилиты из @sima-land/ui-nucleons/test-utils.
  */
 export class FakeIntersectionObserver implements IntersectionObserver {
   readonly root: Element | Document | null;

--- a/src/test-utils/__test__/create-dom-rect-read-only.test.ts
+++ b/src/test-utils/__test__/create-dom-rect-read-only.test.ts
@@ -1,0 +1,57 @@
+import { createDOMRectReadOnly } from '../create-dom-rect-read-only';
+
+describe('createDOMRectReadOnly', () => {
+  it('should return rect without arguments', () => {
+    const result = createDOMRectReadOnly();
+
+    expect(result).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      toJSON: expect.any(Function),
+    });
+
+    expect(result.toJSON()).toEqual({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+    });
+  });
+
+  it('should handle params', () => {
+    const result = createDOMRectReadOnly(10, 20, 30, 40);
+
+    expect(result).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+      left: 10,
+      top: 20,
+      bottom: 60,
+      right: 40,
+      toJSON: expect.any(Function),
+    });
+
+    expect(result.toJSON()).toEqual({
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+      left: 10,
+      top: 20,
+      bottom: 60,
+      right: 40,
+    });
+  });
+});

--- a/src/test-utils/__test__/intersection-observer-mock.test.ts
+++ b/src/test-utils/__test__/intersection-observer-mock.test.ts
@@ -1,0 +1,112 @@
+import { IntersectionObserverMock } from '../intersection-observer-mock';
+
+describe('IntersectionObserverMock', () => {
+  it('should throw error when first argument is not a function', () => {
+    expect(() => {
+      const mock = new IntersectionObserverMock(null as any);
+      return mock;
+    }).toThrow(new TypeError('IntersectionObserverMock constructor: Argument 1 is not callable.'));
+
+    expect(() => {
+      const mock = new IntersectionObserverMock(() => {});
+      return mock;
+    }).not.toThrow();
+  });
+
+  it('should handle different variants of "threshold" option', () => {
+    const fn = () => {};
+    expect(new IntersectionObserverMock(fn, {}).thresholds).toEqual([
+      //
+      0,
+    ]);
+
+    expect(new IntersectionObserverMock(fn, { threshold: 0.2 }).thresholds).toEqual([
+      //
+      0.2,
+    ]);
+
+    expect(new IntersectionObserverMock(fn, { threshold: [0.1, 0.3, 0.5] }).thresholds).toEqual([
+      //
+      0.1, 0.3, 0.5,
+    ]);
+  });
+
+  it('disconnect()', () => {
+    const spy = jest.fn();
+    const mock = new IntersectionObserverMock(spy);
+
+    expect(() => mock.disconnect()).not.toThrow();
+
+    const target = document.createElement('div');
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    mock.disconnect();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('observe()', () => {
+    const spy = jest.fn();
+    const mock = new IntersectionObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    expect(() => mock.observe(target)).not.toThrow();
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('takeRecords()', () => {
+    const spy = jest.fn();
+    const mock = new IntersectionObserverMock(spy);
+
+    expect(() => mock.takeRecords()).not.toThrow();
+  });
+
+  it('unobserve()', () => {
+    const spy = jest.fn();
+    const mock = new IntersectionObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(() => mock.unobserve(target)).not.toThrow();
+
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    mock.unobserve(target);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('simulateEntryChange', () => {
+    const spy = jest.fn();
+    const mock = new IntersectionObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target, isIntersecting: true, intersectionRatio: 0 });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test-utils/create-dom-rect-read-only.ts
+++ b/src/test-utils/create-dom-rect-read-only.ts
@@ -1,0 +1,26 @@
+/**
+ * Создает новый DOMRectReadOnly.
+ * @inheritdoc
+ */
+export function createDOMRectReadOnly(
+  x: number | undefined = 0,
+  y: number | undefined = 0,
+  width: number | undefined = 0,
+  height: number | undefined = 0,
+): DOMRectReadOnly {
+  const rect = {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    bottom: y + height,
+    right: x + width,
+  };
+
+  return {
+    ...rect,
+    toJSON: () => JSON.stringify(rect),
+  };
+}

--- a/src/test-utils/create-dom-rect-read-only.ts
+++ b/src/test-utils/create-dom-rect-read-only.ts
@@ -21,6 +21,8 @@ export function createDOMRectReadOnly(
 
   return {
     ...rect,
-    toJSON: () => JSON.stringify(rect),
+
+    // ВАЖНО: копируем чтобы не было возможности изменить результат
+    toJSON: () => ({ ...rect }),
   };
 }

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,5 @@
+export { IntersectionObserverMock } from './intersection-observer-mock';
+export { createDOMRectReadOnly } from './create-dom-rect-read-only';
+
+// @todo matchMedia mock utils
+// @todo ResizeObserver mock utils

--- a/src/test-utils/intersection-observer-mock.ts
+++ b/src/test-utils/intersection-observer-mock.ts
@@ -1,0 +1,149 @@
+import { createDOMRectReadOnly } from './create-dom-rect-read-only';
+
+const privates = new Map<IntersectionObserverMock, { targets: Set<Element> }>();
+
+/**
+ * Имитация IntersectionObserver.
+ */
+export class IntersectionObserverMock implements IntersectionObserver {
+  /**
+   * Создает новый реестр экземпляров IntersectionObserverMock.
+   * @return Реестр.
+   */
+  static createRegistry() {
+    const items: IntersectionObserverMock[] = [];
+
+    return {
+      getObserver: (...params: ConstructorParameters<typeof IntersectionObserverMock>) => {
+        const item = new IntersectionObserverMock(...params);
+
+        items.push(item);
+
+        return item;
+      },
+
+      /**
+       * Имитирует изменение состояния наблюдаемого элемента на всех экземплярах в реестре.
+       * @param entry Данные состояния.
+       */
+      simulateEntryChange(
+        entry: Pick<IntersectionObserverEntry, 'intersectionRatio' | 'isIntersecting' | 'target'>,
+      ) {
+        items.forEach(item => item.simulateEntryChange(entry));
+      },
+    };
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/root).
+   */
+  readonly root: Element | Document | null;
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/rootMargin).
+   */
+  readonly rootMargin: string;
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/thresholds).
+   */
+  readonly thresholds: ReadonlyArray<number>;
+
+  protected readonly callback: IntersectionObserverCallback;
+  protected readonly options: IntersectionObserverInit | undefined;
+
+  /**
+   * @inheritdoc
+   */
+  constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    // root
+    this.root = options?.root ?? null;
+
+    // rootMargin
+    this.rootMargin = options?.rootMargin ?? '0px';
+
+    // thresholds
+    if (typeof options?.threshold === 'number') {
+      this.thresholds = [options.threshold];
+    } else if (Array.isArray(options?.threshold)) {
+      this.thresholds = options.threshold;
+    } else {
+      this.thresholds = [0];
+    }
+
+    // specific for mock
+    this.callback = callback;
+    this.options = options;
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/disconnect).
+   * @inheritdoc
+   */
+  disconnect(): void {}
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/observe).
+   * @inheritdoc
+   */
+  observe(target: Element): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.add(target);
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/takeRecords).
+   * @inheritdoc
+   */
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/unobserve).
+   * @inheritdoc
+   */
+  unobserve(target: Element): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.delete(target);
+  }
+
+  /**
+   * Имитирует изменение состояния наблюдаемого элемента.
+   * @param entry Данные состояния.
+   */
+  simulateEntryChange({
+    target,
+    isIntersecting,
+    intersectionRatio,
+  }: Pick<IntersectionObserverEntry, 'intersectionRatio' | 'isIntersecting' | 'target'>) {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    if (privates.get(this)?.targets.has(target) && this.thresholds.includes(intersectionRatio)) {
+      this.callback(
+        [
+          {
+            target,
+            isIntersecting,
+            intersectionRatio,
+
+            // not implemented
+            time: Date.now(),
+            boundingClientRect: createDOMRectReadOnly(),
+            intersectionRect: createDOMRectReadOnly(),
+            rootBounds: createDOMRectReadOnly(),
+          },
+        ],
+        this,
+      );
+    }
+  }
+}

--- a/src/test-utils/intersection-observer-mock.ts
+++ b/src/test-utils/intersection-observer-mock.ts
@@ -56,6 +56,11 @@ export class IntersectionObserverMock implements IntersectionObserver {
    * @inheritdoc
    */
   constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+    // ВАЖНО: имитируем поведение согласно реализации в браузере
+    if (typeof callback !== 'function') {
+      throw new TypeError('IntersectionObserverMock constructor: Argument 1 is not callable.');
+    }
+
     // root
     this.root = options?.root ?? null;
 
@@ -80,7 +85,13 @@ export class IntersectionObserverMock implements IntersectionObserver {
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/disconnect).
    * @inheritdoc
    */
-  disconnect(): void {}
+  disconnect(): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.clear();
+  }
 
   /**
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IntersectionObserver/observe).
@@ -99,6 +110,7 @@ export class IntersectionObserverMock implements IntersectionObserver {
    * @inheritdoc
    */
   takeRecords(): IntersectionObserverEntry[] {
+    // not implemented
     return [];
   }
 


### PR DESCRIPTION
- avatar: исправлено название внутренней константы (patch)
- hooks/use-intersection/test-utils: все утилиты помечены как deprecated (patch)
- test-utils: добавлены утилиты IntersectionObserverMock и createDOMRectReadOnly (minor)
- обновлен пакет typescript (patch)
