### PR TITLE
Шаг 2 #413 Добавить моки Web API для удобного использования вместе с соответствующими контекстами

### DIFF
--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -2,21 +2,23 @@
 import { createContext } from 'react';
 
 export const MatchMediaContext = createContext({
-  // ВАЖНО: используем "window.matchMedia" вместо "matchMedia" тк падают ошибки в некоторых браузерах
   matchMedia(query: string) {
     // ВАЖНО: доступ к window.matchMedia должен осуществляться именно в момент вызова а не в момент определения контекста
+    // ВАЖНО: используем "window.matchMedia" вместо "matchMedia" тк падают ошибки в некоторых браузерах
     return window.matchMedia(query);
   },
 });
 
 export const ResizeObserverContext = createContext({
   createResizeObserver(callback: ResizeObserverCallback) {
+    // ВАЖНО: доступ к window.ResizeObserver должен осуществляться именно в момент вызова а не в момент определения контекста
     return new window.ResizeObserver(callback);
   },
 });
 
 export const IntersectionObserverContext = createContext({
   createIntersectionObserver(...args: ConstructorParameters<typeof IntersectionObserver>) {
+    // ВАЖНО: доступ к window.IntersectionObserver должен осуществляться именно в момент вызова а не в момент определения контекста
     return new window.IntersectionObserver(...args);
   },
 });

--- a/src/dropdown/__test__/utils.test.tsx
+++ b/src/dropdown/__test__/utils.test.tsx
@@ -2,6 +2,7 @@ import { useFloating } from '@floating-ui/react';
 import { useDropdownFloatingStyle } from '../utils';
 import { act, render } from '@testing-library/react';
 import { ResizeObserverContext } from '../../context';
+import { ResizeObserverMock } from '../../test-utils';
 
 describe('useDropdownFloatingStyle', () => {
   const TestComponent = () => {
@@ -22,22 +23,10 @@ describe('useDropdownFloatingStyle', () => {
   };
 
   it('should return styles and handle reference element resize', () => {
-    let callback: null | ResizeObserverCallback = null;
-
-    const createResizeObserver = (fn: ResizeObserverCallback) => {
-      callback = fn;
-
-      const observer = {
-        observe: jest.fn(),
-        unobserve: jest.fn(),
-        disconnect: jest.fn(),
-      } as ResizeObserver;
-
-      return observer;
-    };
+    const observers = ResizeObserverMock.createRegistry();
 
     const { getByTestId } = render(
-      <ResizeObserverContext.Provider value={{ createResizeObserver }}>
+      <ResizeObserverContext.Provider value={{ createResizeObserver: observers.getObserver }}>
         <TestComponent />
       </ResizeObserverContext.Provider>,
     );
@@ -59,7 +48,7 @@ describe('useDropdownFloatingStyle', () => {
           left: 0,
         }) as DOMRect;
 
-      callback?.([], {} as any);
+      observers.simulateEntryChange({ target: reference });
     });
 
     expect(getByTestId('floating').style.getPropertyValue('--opener-width')).toBe('320px');

--- a/src/test-utils/__test__/resize-observer-mock.test.ts
+++ b/src/test-utils/__test__/resize-observer-mock.test.ts
@@ -1,0 +1,87 @@
+import { ResizeObserverMock } from '../resize-observer-mock';
+
+describe('ResizeObserverMock', () => {
+  it('should throw error when first argument is not a function', () => {
+    expect(() => {
+      const mock = new ResizeObserverMock(null as any);
+      return mock;
+    }).toThrow(new TypeError('ResizeObserverMock constructor: Argument 1 is not callable.'));
+
+    expect(() => {
+      const mock = new ResizeObserverMock(() => {});
+      return mock;
+    }).not.toThrow();
+  });
+
+  it('disconnect()', () => {
+    const spy = jest.fn();
+    const mock = new ResizeObserverMock(spy);
+
+    expect(() => mock.disconnect()).not.toThrow();
+
+    const target = document.createElement('div');
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    mock.disconnect();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('observe()', () => {
+    const spy = jest.fn();
+    const mock = new ResizeObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    expect(() => mock.observe(target)).not.toThrow();
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('unobserve()', () => {
+    const spy = jest.fn();
+    const mock = new ResizeObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(() => mock.unobserve(target)).not.toThrow();
+
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    mock.unobserve(target);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('simulateEntryChange', () => {
+    const spy = jest.fn();
+    const mock = new ResizeObserverMock(spy);
+    const target = document.createElement('div');
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(0);
+
+    mock.observe(target);
+
+    expect(spy).toHaveBeenCalledTimes(0);
+    mock.simulateEntryChange({ target });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,5 +1,5 @@
 export { IntersectionObserverMock } from './intersection-observer-mock';
+export { ResizeObserverMock } from './resize-observer-mock';
 export { createDOMRectReadOnly } from './create-dom-rect-read-only';
 
 // @todo matchMedia mock utils
-// @todo ResizeObserver mock utils

--- a/src/test-utils/intersection-observer-mock.ts
+++ b/src/test-utils/intersection-observer-mock.ts
@@ -11,27 +11,7 @@ export class IntersectionObserverMock implements IntersectionObserver {
    * @return Реестр.
    */
   static createRegistry() {
-    const items: IntersectionObserverMock[] = [];
-
-    return {
-      getObserver: (...params: ConstructorParameters<typeof IntersectionObserverMock>) => {
-        const item = new IntersectionObserverMock(...params);
-
-        items.push(item);
-
-        return item;
-      },
-
-      /**
-       * Имитирует изменение состояния наблюдаемого элемента на всех экземплярах в реестре.
-       * @param entry Данные состояния.
-       */
-      simulateEntryChange(
-        entry: Pick<IntersectionObserverEntry, 'intersectionRatio' | 'isIntersecting' | 'target'>,
-      ) {
-        items.forEach(item => item.simulateEntryChange(entry));
-      },
-    };
+    return new IntersectionObserverRegistry();
   }
 
   /**
@@ -157,5 +137,45 @@ export class IntersectionObserverMock implements IntersectionObserver {
         this,
       );
     }
+  }
+}
+
+/**
+ * Реестр экземпляров IntersectionObserverMock.
+ */
+export class IntersectionObserverRegistry {
+  protected readonly items: Set<IntersectionObserverMock>;
+
+  /**
+   * @inheritdoc
+   */
+  constructor() {
+    this.items = new Set();
+
+    this.getObserver = this.getObserver.bind(this);
+    this.simulateEntryChange = this.simulateEntryChange.bind(this);
+  }
+
+  /**
+   * Создает, регистрирует и возвращает новый экземпляр IntersectionObserverMock.
+   * @param params Аргументы IntersectionObserverMock.
+   * @return Экземпляр IntersectionObserverMock.
+   */
+  getObserver(...params: ConstructorParameters<typeof IntersectionObserverMock>) {
+    const item = new IntersectionObserverMock(...params);
+
+    this.items.add(item);
+
+    return item;
+  }
+
+  /**
+   * Имитирует изменение состояния наблюдаемого элемента на всех экземплярах в реестре.
+   * @param entry Данные состояния.
+   */
+  simulateEntryChange(
+    entry: Pick<IntersectionObserverEntry, 'intersectionRatio' | 'isIntersecting' | 'target'>,
+  ) {
+    this.items.forEach(item => item.simulateEntryChange(entry));
   }
 }

--- a/src/test-utils/resize-observer-mock.ts
+++ b/src/test-utils/resize-observer-mock.ts
@@ -1,0 +1,131 @@
+import { createDOMRectReadOnly } from './create-dom-rect-read-only';
+
+const privates = new Map<ResizeObserverMock, { targets: Set<Element> }>();
+
+/**
+ * Имитация ResizeObserver.
+ */
+export class ResizeObserverMock implements ResizeObserver {
+  /**
+   * Создает новый реестр экземпляров ResizeObserverMock.
+   * @return Реестр.
+   */
+  static createRegistry() {
+    return new ResizeObserverRegistry();
+  }
+
+  protected readonly callback: ResizeObserverCallback;
+
+  /**
+   * @inheritdoc
+   */
+  constructor(callback: ResizeObserverCallback) {
+    // ВАЖНО: имитируем поведение согласно реализации в браузере
+    if (typeof callback !== 'function') {
+      throw new TypeError('ResizeObserverMock constructor: Argument 1 is not callable.');
+    }
+
+    // specific for mock
+    this.callback = callback;
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ResizeObserver/disconnect).
+   * @inheritdoc
+   */
+  disconnect(): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.clear();
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ResizeObserver/observe).
+   * @inheritdoc
+   */
+  observe(target: Element): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.add(target);
+  }
+
+  /**
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/ResizeObserver/unobserve).
+   * @inheritdoc
+   */
+  unobserve(target: Element): void {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    privates.get(this)?.targets.delete(target);
+  }
+
+  /**
+   * Имитирует изменение состояния наблюдаемого элемента.
+   * @param entry Данные состояния.
+   */
+  simulateEntryChange({ target }: Pick<ResizeObserverEntry, 'target'>) {
+    if (!privates.has(this)) {
+      privates.set(this, { targets: new Set() });
+    }
+
+    if (privates.get(this)?.targets.has(target)) {
+      this.callback(
+        [
+          {
+            target,
+
+            // not implemented
+            borderBoxSize: [],
+            contentBoxSize: [],
+            contentRect: createDOMRectReadOnly(),
+            devicePixelContentBoxSize: [],
+          },
+        ],
+        this,
+      );
+    }
+  }
+}
+
+/**
+ * Реестр экземпляров ResizeObserverMock.
+ */
+export class ResizeObserverRegistry {
+  protected readonly items: Set<ResizeObserverMock>;
+
+  /**
+   * @inheritdoc
+   */
+  constructor() {
+    this.items = new Set();
+    this.getObserver = this.getObserver.bind(this);
+    this.simulateEntryChange = this.simulateEntryChange.bind(this);
+  }
+
+  /**
+   * Создает, регистрирует и возвращает новый экземпляр ResizeObserverMock.
+   * @param params Аргументы ResizeObserverMock.
+   * @return Экземпляр ResizeObserverMock.
+   */
+  getObserver(...params: ConstructorParameters<typeof ResizeObserverMock>) {
+    const item = new ResizeObserverMock(...params);
+
+    this.items.add(item);
+
+    return item;
+  }
+
+  /**
+   * Имитирует изменение состояния наблюдаемого элемента на всех экземплярах в реестре.
+   * @param entry Данные состояния.
+   */
+  simulateEntryChange(entry: Pick<ResizeObserverEntry, 'target'>) {
+    this.items.forEach(item => item.simulateEntryChange(entry));
+  }
+}


### PR DESCRIPTION
- test-utils: добавлен класс ResizeObserverMock (minor)
- test-utils: реализация реестра экземпляров IntersectionObserverMock вынесена в отдельный класс (patch)
- dropdown: переписаны unit-тесты (patch)
- context: мелкие правки комментариев (patch)