### PR TITLE
Шаг 1 #424 Поля ввода текста: в Safari при disabled введенный текст не виден на фоне поля

### DIFF
--- a/src/base-input/__stories__/index.stories.tsx
+++ b/src/base-input/__stories__/index.stories.tsx
@@ -50,7 +50,7 @@ export function RestPlaceholder() {
     width: 200,
     padding: 12,
     border: '1px solid #323232',
-    '--placeholder-color': '#aaa',
+    '--base-input-placeholder-color': '#aaa',
   };
 
   const [value, setValue] = useState<string>('');

--- a/src/base-input/base-input.m.scss
+++ b/src/base-input/base-input.m.scss
@@ -1,4 +1,5 @@
 @use '../utils';
+@use '../colors';
 
 .reset {
   border: 0;
@@ -16,21 +17,32 @@
   flex-grow: 1;
   display: flex;
   overflow: hidden;
+  background: var(--base-input-background);
 }
 
 .field {
   width: 0;
   flex-grow: 1;
   display: block;
-  color: inherit;
+  background: var(--base-input-background);
+  color: var(--base-input-color);
   font-size: inherit;
   line-height: inherit;
-  z-index: 1;
+  z-index: 0;
   text-overflow: inherit;
-  background: inherit;
   &::placeholder {
+    color: var(--base-input-placeholder-color);
+    -webkit-text-fill-color: var(--base-input-placeholder-color);
     opacity: 1;
-    color: var(--placeholder-color);
+  }
+  &:disabled {
+    background: var(--base-input-background);
+    color: var(--base-input-color);
+  }
+  &:disabled::placeholder {
+    color: var(--base-input-placeholder-color);
+    -webkit-text-fill-color: var(--base-input-placeholder-color);
+    opacity: 1;
   }
   &::-ms-clear {
     // отключаем системный крестик в IE
@@ -56,11 +68,11 @@
   font-size: inherit;
   line-height: inherit;
   overflow: hidden;
-  z-index: 0;
+  z-index: 1;
   .shift-part {
     color: transparent;
   }
   .main-part {
-    color: var(--placeholder-color);
+    color: var(--base-input-placeholder-color);
   }
 }

--- a/src/base-input/types.ts
+++ b/src/base-input/types.ts
@@ -10,7 +10,9 @@ export interface RestPlaceholderDefinition {
 }
 
 export interface BaseInputStyle extends CSSProperties {
-  '--placeholder-color'?: string;
+  '--base-input-background'?: string;
+  '--base-input-color'?: string;
+  '--base-input-placeholder-color'?: string;
 }
 
 export interface CommonProps extends WithTestId {

--- a/src/field-block/field-block.m.scss
+++ b/src/field-block/field-block.m.scss
@@ -118,6 +118,7 @@
   pointer-events: none;
   white-space: nowrap;
   overflow: hidden;
+  z-index: 1;
 }
 
 .col {
@@ -148,6 +149,7 @@
   max-width: 100%;
   white-space: nowrap;
   color: var(--field-main-text-color, var(--field-primary-text-color));
+  z-index: 0;
 }
 
 .caption {

--- a/src/input/__test__/index.test.tsx
+++ b/src/input/__test__/index.test.tsx
@@ -105,11 +105,11 @@ describe('Input', () => {
     expect(focusSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('should properly set "--placeholder-color" variable', () => {
+  it('should properly set "--base-input-placeholder-color" variable', () => {
     const { getByTestId, rerender } = render(<Input failed disabled={false} />);
 
     function placeholderColor() {
-      return getByTestId('base-input').style.getPropertyValue('--placeholder-color');
+      return getByTestId('base-input').style.getPropertyValue('--base-input-placeholder-color');
     }
 
     expect(placeholderColor()).toBe(COLORS.get('additional-deep-red'));

--- a/src/input/input.m.scss
+++ b/src/input/input.m.scss
@@ -12,6 +12,13 @@
   background: inherit;
   font: inherit;
   line-height: inherit;
+  --base-input-background: var(--field-background);
+  --base-input-color: var(--field-main-text-color, var(--field-primary-text-color));
+  --base-input-placeholder-color: #{colors.$basic-gray38};
+}
+
+.disabled {
+  --base-input-placeholder-color: #{colors.$basic-gray38};
 }
 
 .clear-button {

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -114,10 +114,10 @@ export function Input({
           {...baseInputProps}
           inputRef={ref}
           multiline={false}
-          className={cx('input', baseInputProps?.className)}
+          className={cx('input', disabled && 'disabled', baseInputProps?.className)}
           style={{
             ...baseInputProps?.style,
-            '--placeholder-color': definePlaceholderColor({ failed, disabled }),
+            '--base-input-placeholder-color': definePlaceholderColor({ failed, disabled }),
           }}
           autoComplete={autoComplete}
           autoFocus={autoFocus}

--- a/src/textarea/__test__/index.test.tsx
+++ b/src/textarea/__test__/index.test.tsx
@@ -96,11 +96,11 @@ describe('Textarea', () => {
     expect(focusSpy).toHaveBeenCalledTimes(0);
   });
 
-  it('should properly set "--placeholder-color" variable', () => {
+  it('should properly set "--base-input-placeholder-color" variable', () => {
     const { getByTestId, rerender } = render(<Textarea failed disabled={false} />);
 
     function placeholderColor() {
-      return getByTestId('base-input').style.getPropertyValue('--placeholder-color');
+      return getByTestId('base-input').style.getPropertyValue('--base-input-placeholder-color');
     }
 
     expect(placeholderColor()).toBe(COLORS.get('additional-deep-red'));

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -88,7 +88,7 @@ export function Textarea({
           className={cx('textarea', baseInputProps?.className)}
           style={{
             ...baseInputProps?.style,
-            '--placeholder-color': definePlaceholderColor({ failed, disabled }),
+            '--base-input-placeholder-color': definePlaceholderColor({ failed, disabled }),
           }}
           autoComplete={autoComplete}
           autoFocus={autoFocus}


### PR DESCRIPTION
- base-input: css-переменная --placeholder-color заменена на --base-input-placeholder-color (major)
- base-input: добавлена возможность задать css-переменные цвета и фона (minor)
- input: заданы цвета для BaseInput явно для правок в safari (patch)
- field-block: правки стилей из-за новой реализации base-input из-за Safari (patch)