### PR TITLE
#476 Input: добавить возможность переопределять css-переменную цвета плейсхолдера

### DIFF
--- a/docs/stories/components/masked-input/04-different-states.story.tsx
+++ b/docs/stories/components/masked-input/04-different-states.story.tsx
@@ -23,6 +23,7 @@ export default function DifferentState() {
           options: [
             { value: 'default', displayName: 'По умолчанию' },
             { value: 'disabled', displayName: 'Отключено' },
+            { value: 'failed', displayName: 'Ошибка' },
           ],
         },
         {
@@ -39,6 +40,7 @@ export default function DifferentState() {
         value={controlled ? value : undefined}
         defaultValue={!controlled ? defaultValue : undefined}
         disabled={state === 'disabled'}
+        failed={state === 'failed'}
         onChange={(event, data) => {
           setValue(data.cleanValue);
         }}

--- a/src/input/__test__/index.test.tsx
+++ b/src/input/__test__/index.test.tsx
@@ -202,4 +202,14 @@ describe('Input', () => {
     rerender(<Input focused />);
     expect(getByTestId('input').classList.contains('focused')).toBe(true);
   });
+
+  it('should handle "--base-input-placeholder-color" in "baseInputProps.style"', () => {
+    const { getByTestId } = render(
+      <Input baseInputProps={{ style: { '--base-input-placeholder-color': 'green' } }} />,
+    );
+
+    expect(getByTestId('base-input').style.getPropertyValue('--base-input-placeholder-color')).toBe(
+      'green',
+    );
+  });
 });

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -116,8 +116,8 @@ export function Input({
           multiline={false}
           className={cx('input', disabled && 'disabled', baseInputProps?.className)}
           style={{
-            ...baseInputProps?.style,
             '--base-input-placeholder-color': definePlaceholderColor({ failed, disabled }),
+            ...baseInputProps?.style,
           }}
           autoComplete={autoComplete}
           autoFocus={autoFocus}

--- a/src/textarea/__test__/index.test.tsx
+++ b/src/textarea/__test__/index.test.tsx
@@ -147,4 +147,14 @@ describe('Textarea', () => {
     expect(find('[data-testid="message"] [data-testid="base-input"] textarea')).toHaveLength(1);
     expect(find('[data-testid="message"] [data-testid="base-input:field"]')).toHaveLength(1);
   });
+
+  it('should handle "--base-input-placeholder-color" in "baseInputProps.style"', () => {
+    const { getByTestId } = render(
+      <Textarea baseInputProps={{ style: { '--base-input-placeholder-color': 'green' } }} />,
+    );
+
+    expect(getByTestId('base-input').style.getPropertyValue('--base-input-placeholder-color')).toBe(
+      'green',
+    );
+  });
 });

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -87,8 +87,8 @@ export function Textarea({
           multiline
           className={cx('textarea', baseInputProps?.className)}
           style={{
-            ...baseInputProps?.style,
             '--base-input-placeholder-color': definePlaceholderColor({ failed, disabled }),
+            ...baseInputProps?.style,
           }}
           autoComplete={autoComplete}
           autoFocus={autoFocus}
@@ -101,21 +101,21 @@ export function Textarea({
           required={required}
           rows={rows}
           value={value}
-          onFocus={(event: any) => {
+          onFocus={event => {
             onFocus?.(event);
             updateFilled(event);
             setFocused(true);
           }}
-          onBlur={(event: any) => {
+          onBlur={event => {
             onBlur?.(event);
             updateFilled(event);
             setFocused(false);
           }}
-          onInput={(event: any) => {
+          onInput={event => {
             onInput?.(event);
             updateFilled(event);
           }}
-          onChange={(event: any) => {
+          onChange={event => {
             onChange?.(event);
             updateFilled(event);
           }}

--- a/src/textarea/types.ts
+++ b/src/textarea/types.ts
@@ -26,7 +26,7 @@ export interface TextareaProps extends HTMLTextareaProps, FieldBlockProps {
   textareaRef?: Ref<HTMLTextAreaElement>;
 
   /** Свойства BaseInputProps. */
-  baseInputProps?: BaseInputAsTextareaProps;
+  baseInputProps?: Omit<BaseInputAsTextareaProps, 'multiline'>;
 
   /** Стили корневого элемента. */
   style?: Required<FieldBlockProps>['rootProps']['style'];


### PR DESCRIPTION
- input: добавлена возможность переопределить `--base-input-placeholder-color`
- textarea: добавлена возможность переопределить `--base-input-placeholder-color`
- textarea: мелкие правки типов