### PR TITLE
Не работает клик после драг-н-дропа в карусели

### DIFF
--- a/src/carousel/__test__/draggable.test.tsx
+++ b/src/carousel/__test__/draggable.test.tsx
@@ -175,6 +175,34 @@ describe('Draggable', () => {
     Object.defineProperty(Document.prototype, 'activeElement', activeElementDescriptor as any);
   });
 
+  it('isPointInRect() should return true if the cursor is within the parent', () => {
+    const instance = new Draggable({});
+    const mockParentElement = document.createElement('div');
+    const event = new MouseEvent('test', { clientX: 150, clientY: 150 });
+
+    mockParentElement.getBoundingClientRect = jest.fn().mockReturnValue({
+      left: 100,
+      right: 200,
+      top: 100,
+      bottom: 200,
+    });
+
+    instance.draggableRef = {
+      current: {
+        ...mockParentElement,
+        parentElement: mockParentElement,
+      },
+    };
+
+    expect(instance.isPointInRect(event)).toBeTruthy();
+  });
+
+  it('isPointInRect() should return false if the cursor is not within the parent', () => {
+    const instance = new Draggable({});
+
+    expect(instance.isPointInRect(new MouseEvent('test'))).toBeFalsy();
+  });
+
   it('handleMove() should do nothing when isGrabbed false', () => {
     const instance = new Draggable({});
 

--- a/src/carousel/draggable.tsx
+++ b/src/carousel/draggable.tsx
@@ -15,7 +15,7 @@ import {
   getEventClientPos,
   EventWithPosition,
 } from '../helpers/events';
-import { on } from '../helpers/on';
+import { on } from '../helpers';
 import classnames from 'classnames/bind';
 import styles from './draggable.m.scss';
 
@@ -162,6 +162,25 @@ export class Draggable extends Component<DraggableProps> {
   }
 
   /**
+   * Проверяет, находится ли курсор в области родителя draggable.
+   * @param event Событие окончания захвата.
+   * @return Boolean Флаг нахождения курсора в пределах родителя draggable.
+   */
+  isPointInRect(event: MouseEvent | TouchEvent) {
+    const container = this.draggableRef.current?.parentElement;
+    const rect = container?.getBoundingClientRect();
+    const point = getEventClientPos(event);
+
+    return Boolean(
+      rect &&
+        point.x >= rect.left &&
+        point.x <= rect.right &&
+        point.y >= rect.top &&
+        point.y <= rect.bottom,
+    );
+  }
+
+  /**
    * Обновляет смещение и все данные при необходимости.
    * @param event Событие передвижения.
    */
@@ -183,8 +202,7 @@ export class Draggable extends Component<DraggableProps> {
         event.preventDefault();
         window.getSelection()?.removeAllRanges();
 
-        // предотвращаем клик только на НЕ touch-устройствах тк на них срабатывает клик при перетаскивании
-        this.togglePreventClickNeed(true);
+        this.togglePreventClickNeed(this.isPointInRect(event));
       }
 
       onDragMove && onDragMove(customEvent);

--- a/src/carousel/draggable.tsx
+++ b/src/carousel/draggable.tsx
@@ -202,6 +202,10 @@ export class Draggable extends Component<DraggableProps> {
         event.preventDefault();
         window.getSelection()?.removeAllRanges();
 
+        /*
+        Предотвращаем клик, если курсор в области карусели, иначе нет.
+        Только НЕ touch-устройства т.к. на них срабатывает клик при перетаскивании.
+        */
         this.togglePreventClickNeed(this.isPointInRect(event));
       }
 


### PR DESCRIPTION
- Исправлено поведение блокировки клика после драг-н-дропа в карусели: блокируем клик, если курсор в пределах карусели, иначе нет.
- Отображено в тестах, проверено локально