### PR TITLE
#12351 Реализовать возможность отключать проверку на заполненность маски при достижении минимального необходимого значения

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "jest-environment-jsdom": "^29.3.1",
         "lint-staged": "^12.3.5",
         "postcss": "^8.4.24",
-        "prettier": "^3.1.1",
+        "prettier": "^3.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.83.4",
@@ -12706,10 +12706,11 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -24074,9 +24075,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true
     },
     "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,12 +75,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -413,19 +415,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -454,40 +458,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1842,9 +1833,10 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1853,14 +1845,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1885,14 +1878,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4851,33 +4844,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ansi-styles/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/ansi-styles/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -5488,20 +5454,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -6510,15 +6462,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/escodegen": {
@@ -7614,15 +7557,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -14026,18 +13960,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-hyperlinks": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
@@ -14293,15 +14215,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -15166,12 +15079,13 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       }
     },
@@ -15418,15 +15332,15 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -15447,34 +15361,22 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/parser": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -16374,22 +16276,22 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
-      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
     },
     "@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       }
     },
     "@babel/traverse": {
@@ -16408,14 +16310,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       }
     },
     "@bcoe/v8-coverage": {
@@ -18435,32 +18336,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        }
-      }
-    },
     "anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -18897,17 +18772,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
       "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
       "dev": true
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
     },
     "char-regex": {
       "version": "1.0.2",
@@ -19675,12 +19539,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "escodegen": {
@@ -20477,12 +20335,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "has-property-descriptors": {
@@ -25146,15 +24998,6 @@
         "postcss-value-parser": "^4.2.0"
       }
     },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
     "supports-hyperlinks": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
@@ -25366,12 +25209,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest-environment-jsdom": "^29.3.1",
     "lint-staged": "^12.3.5",
     "postcss": "^8.4.24",
-    "prettier": "^3.1.1",
+    "prettier": "^3.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "^1.83.4",

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,26 +1,28 @@
-declare module '*.jpg' {
-  export default string;
+declare module "*.jpg" {
+  const value: string;
+  export default value;
 }
-declare module '*.png' {
-  export default string;
+declare module "*.png" {
+  const value: string;
+  export default value;
 }
 
 // css-модули
-declare module '*.module.css' {
+declare module "*.module.css" {
   const classes: { [key: string]: string };
   export default classes;
 }
-declare module '*.m.css' {
+declare module "*.m.css" {
   const classes: { [key: string]: string };
   export default classes;
 }
 
 // css-модули с синтаксисом SCSS
-declare module '*.module.scss' {
+declare module "*.module.scss" {
   const classes: { [key: string]: string };
   export default classes;
 }
-declare module '*.m.scss' {
+declare module "*.m.scss" {
   const classes: { [key: string]: string };
   export default classes;
 }

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,28 +1,28 @@
-declare module "*.jpg" {
+declare module '*.jpg' {
   const value: string;
   export default value;
 }
-declare module "*.png" {
+declare module '*.png' {
   const value: string;
   export default value;
 }
 
 // css-модули
-declare module "*.module.css" {
+declare module '*.module.css' {
   const classes: { [key: string]: string };
   export default classes;
 }
-declare module "*.m.css" {
+declare module '*.m.css' {
   const classes: { [key: string]: string };
   export default classes;
 }
 
 // css-модули с синтаксисом SCSS
-declare module "*.module.scss" {
+declare module '*.module.scss' {
   const classes: { [key: string]: string };
   export default classes;
 }
-declare module "*.m.scss" {
+declare module '*.m.scss' {
   const classes: { [key: string]: string };
   export default classes;
 }

--- a/src/masked-input/__test__/masked-input.test.tsx
+++ b/src/masked-input/__test__/masked-input.test.tsx
@@ -1,18 +1,18 @@
-import { createRef, useState } from "react";
-import { fireEvent, render } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { MaskedInput } from "../masked-input";
+import { createRef, useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MaskedInput } from '../masked-input';
 
-describe("MaskedInput", () => {
-  it("should renders Input", async () => {
+describe('MaskedInput', () => {
+  it('should renders Input', async () => {
     const TestComponent = () => {
-      const [value, setValue] = useState("12a3");
+      const [value, setValue] = useState('12a3');
 
       return (
         <MaskedInput
-          mask="____"
-          placeholder="_"
-          pattern={"\\d"}
+          mask='____'
+          placeholder='_'
+          pattern={'\\d'}
           value={value}
           onChange={(event, data) => setValue(data.cleanValue)}
         />
@@ -21,26 +21,22 @@ describe("MaskedInput", () => {
 
     const { queryAllByTestId, getByTestId } = render(<TestComponent />);
 
-    expect(queryAllByTestId("input")).toHaveLength(1);
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "123",
-    );
+    expect(queryAllByTestId('input')).toHaveLength(1);
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('123');
 
-    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "1234",
-    );
+    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('1234');
   });
 
-  it("should work as uncontrolled", async () => {
+  it('should work as uncontrolled', async () => {
     const TestComponent = () => {
-      const [value, setValue] = useState("12a3");
+      const [value, setValue] = useState('12a3');
 
       return (
         <MaskedInput
-          mask="____"
-          placeholder="_"
-          pattern={"\\d"}
+          mask='____'
+          placeholder='_'
+          pattern={'\\d'}
           value={value}
           onChange={(event, data) => setValue(data.cleanValue)}
         />
@@ -49,154 +45,119 @@ describe("MaskedInput", () => {
 
     const { queryAllByTestId, getByTestId } = render(<TestComponent />);
 
-    expect(queryAllByTestId("input")).toHaveLength(1);
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "123",
-    );
+    expect(queryAllByTestId('input')).toHaveLength(1);
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('123');
 
-    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "1234",
-    );
+    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('1234');
   });
 
-  it("should work as uncontrolled without defaultValue", async () => {
+  it('should work as uncontrolled without defaultValue', async () => {
     const spy = jest.fn();
     const { queryAllByTestId, getByTestId } = render(
-      <MaskedInput
-        mask="____"
-        placeholder="_"
-        pattern={"\\d"}
-        onChange={spy}
-      />,
+      <MaskedInput mask='____' placeholder='_' pattern={'\\d'} onChange={spy} />,
     );
 
-    expect(queryAllByTestId("input")).toHaveLength(1);
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "",
-    );
+    expect(queryAllByTestId('input')).toHaveLength(1);
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
 
-    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "456",
-    );
+    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('456');
   });
 
-  it("should apply digits only mask by default", async () => {
+  it('should apply digits only mask by default', async () => {
     const spy = jest.fn();
-    const { queryAllByTestId, getByTestId } = render(
-      <MaskedInput mask="___" onChange={spy} />,
-    );
+    const { queryAllByTestId, getByTestId } = render(<MaskedInput mask='___' onChange={spy} />);
 
-    expect(queryAllByTestId("input")).toHaveLength(1);
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "",
-    );
+    expect(queryAllByTestId('input')).toHaveLength(1);
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
 
-    await userEvent.type(getByTestId("base-input:field"), "AAA3G5__4");
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "354",
-    );
+    await userEvent.type(getByTestId('base-input:field'), 'AAA3G5__4');
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('354');
   });
 
   it('should handle "inputRef" prop', () => {
     const ref = createRef<HTMLInputElement>();
-    const { getByTestId } = render(<MaskedInput mask="___" inputRef={ref} />);
+    const { getByTestId } = render(<MaskedInput mask='___' inputRef={ref} />);
 
     expect(ref.current instanceof HTMLInputElement).toBe(true);
-    expect(getByTestId("base-input:field") === ref.current).toBe(true);
+    expect(getByTestId('base-input:field') === ref.current).toBe(true);
   });
 
   it('should handle "onBlur" prop', () => {
     const spy = jest.fn();
-    const { getByTestId } = render(<MaskedInput mask="____" onBlur={spy} />);
+    const { getByTestId } = render(<MaskedInput mask='____' onBlur={spy} />);
 
     expect(spy).toHaveBeenCalledTimes(0);
-    fireEvent.blur(getByTestId("base-input:field"));
+    fireEvent.blur(getByTestId('base-input:field'));
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should handle "baseInputProps.restPlaceholder" prop', () => {
     const { rerender, getByTestId, queryAllByTestId } = render(
-      <MaskedInput mask="____" value="22" onChange={jest.fn()} />,
+      <MaskedInput mask='____' value='22' onChange={jest.fn()} />,
     );
 
-    expect(getByTestId("rest-placeholder-shift").textContent).toBe("22");
-    expect(getByTestId("rest-placeholder").textContent).toBe("__");
+    expect(getByTestId('rest-placeholder-shift').textContent).toBe('22');
+    expect(getByTestId('rest-placeholder').textContent).toBe('__');
 
     rerender(
       <MaskedInput
-        mask="____"
-        value="22"
+        mask='____'
+        value='22'
         onChange={jest.fn()}
         baseInputProps={{
-          restPlaceholder: { value: "", shiftValue: "" },
+          restPlaceholder: { value: '', shiftValue: '' },
         }}
       />,
     );
 
-    expect(queryAllByTestId("rest-placeholder-shift")).toHaveLength(0);
-    expect(queryAllByTestId("rest-placeholder")).toHaveLength(0);
+    expect(queryAllByTestId('rest-placeholder-shift')).toHaveLength(0);
+    expect(queryAllByTestId('rest-placeholder')).toHaveLength(0);
   });
 
-  it("should handle undefined as value during rerender", () => {
+  it('should handle undefined as value during rerender', () => {
     const spy = jest.fn();
 
     const { rerender, getByTestId } = render(
-      <MaskedInput mask="_-_-_-_" value="2222" onChange={spy} />,
+      <MaskedInput mask='_-_-_-_' value='2222' onChange={spy} />,
     );
 
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "2-2-2-2",
-    );
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('2-2-2-2');
 
-    rerender(<MaskedInput mask="_-_-_-_" value="3333" onChange={spy} />);
+    rerender(<MaskedInput mask='_-_-_-_' value='3333' onChange={spy} />);
 
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "3-3-3-3",
-    );
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('3-3-3-3');
 
-    rerender(<MaskedInput mask="_-_-_-_" value={undefined} onChange={spy} />);
+    rerender(<MaskedInput mask='_-_-_-_' value={undefined} onChange={spy} />);
 
-    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
-      "",
-    );
+    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
   });
 
   it('should handle "filledMaskMinLength" prop', () => {
     const spy = jest.fn();
     const { getByTestId, rerender } = render(
-      <MaskedInput
-        mask="_______________"
-        filledMaskMinLength={5}
-        value="1234"
-        onBlur={spy}
-      />,
+      <MaskedInput mask='_______________' filledMaskMinLength={5} value='1234' onBlur={spy} />,
     );
 
-    fireEvent.blur(getByTestId("base-input:field"));
+    fireEvent.blur(getByTestId('base-input:field'));
 
     expect(spy).toHaveBeenCalledWith(expect.any(Object), {
-      cleanValue: "1234",
+      cleanValue: '1234',
       completed: false,
-      value: "1234",
+      value: '1234',
     });
 
     rerender(
-      <MaskedInput
-        mask="_______________"
-        filledMaskMinLength={5}
-        value="12345"
-        onBlur={spy}
-      />,
+      <MaskedInput mask='_______________' filledMaskMinLength={5} value='12345' onBlur={spy} />,
     );
 
-    fireEvent.blur(getByTestId("base-input:field"));
+    fireEvent.blur(getByTestId('base-input:field'));
 
     expect(spy).toHaveBeenCalledWith(expect.any(Object), {
-      cleanValue: "12345",
+      cleanValue: '12345',
       completed: true,
-      value: "12345",
+      value: '12345',
     });
   });
 });

--- a/src/masked-input/__test__/masked-input.test.tsx
+++ b/src/masked-input/__test__/masked-input.test.tsx
@@ -1,18 +1,18 @@
-import { createRef, useState } from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MaskedInput } from '../masked-input';
+import { createRef, useState } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MaskedInput } from "../masked-input";
 
-describe('MaskedInput', () => {
-  it('should renders Input', async () => {
+describe("MaskedInput", () => {
+  it("should renders Input", async () => {
     const TestComponent = () => {
-      const [value, setValue] = useState('12a3');
+      const [value, setValue] = useState("12a3");
 
       return (
         <MaskedInput
-          mask='____'
-          placeholder='_'
-          pattern={'\\d'}
+          mask="____"
+          placeholder="_"
+          pattern={"\\d"}
           value={value}
           onChange={(event, data) => setValue(data.cleanValue)}
         />
@@ -21,116 +21,182 @@ describe('MaskedInput', () => {
 
     const { queryAllByTestId, getByTestId } = render(<TestComponent />);
 
-    expect(queryAllByTestId('input')).toHaveLength(1);
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('123');
-
-    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('1234');
-  });
-
-  it('should work as uncontrolled', async () => {
-    const TestComponent = () => {
-      const [value, setValue] = useState('12a3');
-
-      return (
-        <MaskedInput
-          mask='____'
-          placeholder='_'
-          pattern={'\\d'}
-          value={value}
-          onChange={(event, data) => setValue(data.cleanValue)}
-        />
-      );
-    };
-
-    const { queryAllByTestId, getByTestId } = render(<TestComponent />);
-
-    expect(queryAllByTestId('input')).toHaveLength(1);
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('123');
-
-    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('1234');
-  });
-
-  it('should work as uncontrolled without defaultValue', async () => {
-    const spy = jest.fn();
-    const { queryAllByTestId, getByTestId } = render(
-      <MaskedInput mask='____' placeholder='_' pattern={'\\d'} onChange={spy} />,
+    expect(queryAllByTestId("input")).toHaveLength(1);
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "123",
     );
 
-    expect(queryAllByTestId('input')).toHaveLength(1);
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
-
-    await userEvent.type(getByTestId('base-input:field'), 'foo4_5_6');
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('456');
+    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "1234",
+    );
   });
 
-  it('should apply digits only mask by default', async () => {
+  it("should work as uncontrolled", async () => {
+    const TestComponent = () => {
+      const [value, setValue] = useState("12a3");
+
+      return (
+        <MaskedInput
+          mask="____"
+          placeholder="_"
+          pattern={"\\d"}
+          value={value}
+          onChange={(event, data) => setValue(data.cleanValue)}
+        />
+      );
+    };
+
+    const { queryAllByTestId, getByTestId } = render(<TestComponent />);
+
+    expect(queryAllByTestId("input")).toHaveLength(1);
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "123",
+    );
+
+    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "1234",
+    );
+  });
+
+  it("should work as uncontrolled without defaultValue", async () => {
     const spy = jest.fn();
-    const { queryAllByTestId, getByTestId } = render(<MaskedInput mask='___' onChange={spy} />);
+    const { queryAllByTestId, getByTestId } = render(
+      <MaskedInput
+        mask="____"
+        placeholder="_"
+        pattern={"\\d"}
+        onChange={spy}
+      />,
+    );
 
-    expect(queryAllByTestId('input')).toHaveLength(1);
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
+    expect(queryAllByTestId("input")).toHaveLength(1);
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "",
+    );
 
-    await userEvent.type(getByTestId('base-input:field'), 'AAA3G5__4');
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('354');
+    await userEvent.type(getByTestId("base-input:field"), "foo4_5_6");
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "456",
+    );
+  });
+
+  it("should apply digits only mask by default", async () => {
+    const spy = jest.fn();
+    const { queryAllByTestId, getByTestId } = render(
+      <MaskedInput mask="___" onChange={spy} />,
+    );
+
+    expect(queryAllByTestId("input")).toHaveLength(1);
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "",
+    );
+
+    await userEvent.type(getByTestId("base-input:field"), "AAA3G5__4");
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "354",
+    );
   });
 
   it('should handle "inputRef" prop', () => {
     const ref = createRef<HTMLInputElement>();
-    const { getByTestId } = render(<MaskedInput mask='___' inputRef={ref} />);
+    const { getByTestId } = render(<MaskedInput mask="___" inputRef={ref} />);
 
     expect(ref.current instanceof HTMLInputElement).toBe(true);
-    expect(getByTestId('base-input:field') === ref.current).toBe(true);
+    expect(getByTestId("base-input:field") === ref.current).toBe(true);
   });
 
   it('should handle "onBlur" prop', () => {
     const spy = jest.fn();
-    const { getByTestId } = render(<MaskedInput mask='____' onBlur={spy} />);
+    const { getByTestId } = render(<MaskedInput mask="____" onBlur={spy} />);
 
     expect(spy).toHaveBeenCalledTimes(0);
-    fireEvent.blur(getByTestId('base-input:field'));
+    fireEvent.blur(getByTestId("base-input:field"));
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('should handle "baseInputProps.restPlaceholder" prop', () => {
     const { rerender, getByTestId, queryAllByTestId } = render(
-      <MaskedInput mask='____' value='22' onChange={jest.fn()} />,
+      <MaskedInput mask="____" value="22" onChange={jest.fn()} />,
     );
 
-    expect(getByTestId('rest-placeholder-shift').textContent).toBe('22');
-    expect(getByTestId('rest-placeholder').textContent).toBe('__');
+    expect(getByTestId("rest-placeholder-shift").textContent).toBe("22");
+    expect(getByTestId("rest-placeholder").textContent).toBe("__");
 
     rerender(
       <MaskedInput
-        mask='____'
-        value='22'
+        mask="____"
+        value="22"
         onChange={jest.fn()}
         baseInputProps={{
-          restPlaceholder: { value: '', shiftValue: '' },
+          restPlaceholder: { value: "", shiftValue: "" },
         }}
       />,
     );
 
-    expect(queryAllByTestId('rest-placeholder-shift')).toHaveLength(0);
-    expect(queryAllByTestId('rest-placeholder')).toHaveLength(0);
+    expect(queryAllByTestId("rest-placeholder-shift")).toHaveLength(0);
+    expect(queryAllByTestId("rest-placeholder")).toHaveLength(0);
   });
 
-  it('should handle undefined as value during rerender', () => {
+  it("should handle undefined as value during rerender", () => {
     const spy = jest.fn();
 
     const { rerender, getByTestId } = render(
-      <MaskedInput mask='_-_-_-_' value='2222' onChange={spy} />,
+      <MaskedInput mask="_-_-_-_" value="2222" onChange={spy} />,
     );
 
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('2-2-2-2');
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "2-2-2-2",
+    );
 
-    rerender(<MaskedInput mask='_-_-_-_' value='3333' onChange={spy} />);
+    rerender(<MaskedInput mask="_-_-_-_" value="3333" onChange={spy} />);
 
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('3-3-3-3');
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "3-3-3-3",
+    );
 
-    rerender(<MaskedInput mask='_-_-_-_' value={undefined} onChange={spy} />);
+    rerender(<MaskedInput mask="_-_-_-_" value={undefined} onChange={spy} />);
 
-    expect((getByTestId('base-input:field') as HTMLInputElement).value).toBe('');
+    expect((getByTestId("base-input:field") as HTMLInputElement).value).toBe(
+      "",
+    );
+  });
+
+  it('should handle "filledMaskMinLength" prop', () => {
+    const spy = jest.fn();
+    const { getByTestId, rerender } = render(
+      <MaskedInput
+        mask="_______________"
+        filledMaskMinLength={5}
+        value="1234"
+        onBlur={spy}
+      />,
+    );
+
+    fireEvent.blur(getByTestId("base-input:field"));
+
+    expect(spy).toHaveBeenCalledWith(expect.any(Object), {
+      cleanValue: "1234",
+      completed: false,
+      value: "1234",
+    });
+
+    rerender(
+      <MaskedInput
+        mask="_______________"
+        filledMaskMinLength={5}
+        value="12345"
+        onBlur={spy}
+      />,
+    );
+
+    fireEvent.blur(getByTestId("base-input:field"));
+
+    expect(spy).toHaveBeenCalledWith(expect.any(Object), {
+      cleanValue: "12345",
+      completed: true,
+      value: "12345",
+    });
   });
 });

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -61,16 +61,17 @@ function StatelessMaskedInput({
     () => bind.ref.current,
   );
 
-  const getMaskData = useCallback(
-    (): MaskData => ({
-      value: store.getState().value,
-      cleanValue: ValueUtil.maskedToClean({ mask, placeholder }, store.getState().value),
+  const getMaskData = useCallback((): MaskData => {
+    const { value: maskedValue } = store.getState();
+
+    return {
+      value: maskedValue,
+      cleanValue: ValueUtil.maskedToClean({ mask, placeholder }, maskedValue),
       completed:
-        store.getState().value.length === mask.length ||
-        Boolean(filledMaskMinLength && store.getState().value.length >= filledMaskMinLength),
-    }),
-    [store, mask, placeholder],
-  );
+        maskedValue.length === mask.length ||
+        Boolean(filledMaskMinLength && maskedValue.length >= filledMaskMinLength),
+    };
+  }, [store, mask, placeholder, filledMaskMinLength]);
 
   return (
     <Input

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -1,31 +1,22 @@
-import { useCallback, useImperativeHandle, useMemo, useState } from "react";
-import { Input } from "../input";
-import { ValueUtil } from "@krutoo/input-mask/dom";
-import { useInputMask } from "./use-input-mask";
-import { MaskData, MaskedInputProps } from "./types";
+import { useCallback, useImperativeHandle, useMemo, useState } from 'react';
+import { Input } from '../input';
+import { ValueUtil } from '@krutoo/input-mask/dom';
+import { useInputMask } from './use-input-mask';
+import { MaskData, MaskedInputProps } from './types';
 
 /**
  * Поле ввода текста по маске.
  * @param props Свойства.
  * @return Элемент.
  */
-export function MaskedInput({
-  value,
-  defaultValue,
-  onChange,
-  ...restProps
-}: MaskedInputProps) {
-  const stateless = useMemo(() => typeof value !== "undefined", []);
+export function MaskedInput({ value, defaultValue, onChange, ...restProps }: MaskedInputProps) {
+  const stateless = useMemo(() => typeof value !== 'undefined', []);
 
   // ВАЖНО: при defaultValue состояние должно быть именно здесь (на уровень выше хука маски) для корректной работы
-  const [currentValue, setCurrentValue] = useState(
-    () => value ?? defaultValue ?? "",
-  );
+  const [currentValue, setCurrentValue] = useState(() => value ?? defaultValue ?? '');
 
   if (stateless) {
-    return (
-      <StatelessMaskedInput {...restProps} value={value} onChange={onChange} />
-    );
+    return <StatelessMaskedInput {...restProps} value={value} onChange={onChange} />;
   }
 
   return (
@@ -48,9 +39,9 @@ export function MaskedInput({
  */
 function StatelessMaskedInput({
   mask,
-  placeholder = "_",
-  pattern = "\\d",
-  value = "",
+  placeholder = '_',
+  pattern = '\\d',
+  value = '',
   baseInputProps,
   onFocus,
   onChange,
@@ -59,7 +50,7 @@ function StatelessMaskedInput({
   inputRef,
   filledMaskMinLength,
   ...restProps
-}: Omit<MaskedInputProps, "defaultValue">) {
+}: Omit<MaskedInputProps, 'defaultValue'>) {
   const { store, bind } = useInputMask({
     value,
     maskOptions: { mask, pattern, placeholder },
@@ -73,16 +64,10 @@ function StatelessMaskedInput({
   const getMaskData = useCallback(
     (): MaskData => ({
       value: store.getState().value,
-      cleanValue: ValueUtil.maskedToClean(
-        { mask, placeholder },
-        store.getState().value,
-      ),
+      cleanValue: ValueUtil.maskedToClean({ mask, placeholder }, store.getState().value),
       completed:
         store.getState().value.length === mask.length ||
-        Boolean(
-          filledMaskMinLength &&
-            store.getState().value.length >= filledMaskMinLength,
-        ),
+        Boolean(filledMaskMinLength && store.getState().value.length >= filledMaskMinLength),
     }),
     [store, mask, placeholder],
   );
@@ -99,19 +84,19 @@ function StatelessMaskedInput({
       }}
       inputRef={bind.ref}
       value={bind.value}
-      onFocus={(event) => {
+      onFocus={event => {
         onFocus?.(event, getMaskData());
       }}
-      onInput={(event) => {
+      onInput={event => {
         bind.onInput(event);
         onInput?.(event, getMaskData());
       }}
-      onChange={(event) => {
+      onChange={event => {
         // @todo следующая строка нужна чтобы в testing-library работал fireEvent.change, решить как быть
         // bind.onInput(event);
         onChange?.(event, getMaskData());
       }}
-      onBlur={(event) => {
+      onBlur={event => {
         onBlur?.(event, getMaskData());
       }}
     />

--- a/src/masked-input/masked-input.tsx
+++ b/src/masked-input/masked-input.tsx
@@ -1,22 +1,31 @@
-import { useCallback, useImperativeHandle, useMemo, useState } from 'react';
-import { Input } from '../input';
-import { ValueUtil } from '@krutoo/input-mask/dom';
-import { useInputMask } from './use-input-mask';
-import { MaskData, MaskedInputProps } from './types';
+import { useCallback, useImperativeHandle, useMemo, useState } from "react";
+import { Input } from "../input";
+import { ValueUtil } from "@krutoo/input-mask/dom";
+import { useInputMask } from "./use-input-mask";
+import { MaskData, MaskedInputProps } from "./types";
 
 /**
  * Поле ввода текста по маске.
  * @param props Свойства.
  * @return Элемент.
  */
-export function MaskedInput({ value, defaultValue, onChange, ...restProps }: MaskedInputProps) {
-  const stateless = useMemo(() => typeof value !== 'undefined', []);
+export function MaskedInput({
+  value,
+  defaultValue,
+  onChange,
+  ...restProps
+}: MaskedInputProps) {
+  const stateless = useMemo(() => typeof value !== "undefined", []);
 
   // ВАЖНО: при defaultValue состояние должно быть именно здесь (на уровень выше хука маски) для корректной работы
-  const [currentValue, setCurrentValue] = useState(() => value ?? defaultValue ?? '');
+  const [currentValue, setCurrentValue] = useState(
+    () => value ?? defaultValue ?? "",
+  );
 
   if (stateless) {
-    return <StatelessMaskedInput {...restProps} value={value} onChange={onChange} />;
+    return (
+      <StatelessMaskedInput {...restProps} value={value} onChange={onChange} />
+    );
   }
 
   return (
@@ -39,17 +48,18 @@ export function MaskedInput({ value, defaultValue, onChange, ...restProps }: Mas
  */
 function StatelessMaskedInput({
   mask,
-  placeholder = '_',
-  pattern = '\\d',
-  value = '',
+  placeholder = "_",
+  pattern = "\\d",
+  value = "",
   baseInputProps,
   onFocus,
   onChange,
   onInput,
   onBlur,
   inputRef,
+  filledMaskMinLength,
   ...restProps
-}: Omit<MaskedInputProps, 'defaultValue'>) {
+}: Omit<MaskedInputProps, "defaultValue">) {
   const { store, bind } = useInputMask({
     value,
     maskOptions: { mask, pattern, placeholder },
@@ -63,8 +73,16 @@ function StatelessMaskedInput({
   const getMaskData = useCallback(
     (): MaskData => ({
       value: store.getState().value,
-      cleanValue: ValueUtil.maskedToClean({ mask, placeholder }, store.getState().value),
-      completed: store.getState().value.length === mask.length,
+      cleanValue: ValueUtil.maskedToClean(
+        { mask, placeholder },
+        store.getState().value,
+      ),
+      completed:
+        store.getState().value.length === mask.length ||
+        Boolean(
+          filledMaskMinLength &&
+            store.getState().value.length >= filledMaskMinLength,
+        ),
     }),
     [store, mask, placeholder],
   );
@@ -81,19 +99,19 @@ function StatelessMaskedInput({
       }}
       inputRef={bind.ref}
       value={bind.value}
-      onFocus={event => {
+      onFocus={(event) => {
         onFocus?.(event, getMaskData());
       }}
-      onInput={event => {
+      onInput={(event) => {
         bind.onInput(event);
         onInput?.(event, getMaskData());
       }}
-      onChange={event => {
+      onChange={(event) => {
         // @todo следующая строка нужна чтобы в testing-library работал fireEvent.change, решить как быть
         // bind.onInput(event);
         onChange?.(event, getMaskData());
       }}
-      onBlur={event => {
+      onBlur={(event) => {
         onBlur?.(event, getMaskData());
       }}
     />

--- a/src/masked-input/types.ts
+++ b/src/masked-input/types.ts
@@ -1,7 +1,13 @@
-import type { Action, Store } from 'redux';
-import type { InputState } from '@krutoo/input-mask/core';
-import type { InputProps } from '../input';
-import type { ChangeEvent, FocusEvent, FormEvent, FormEventHandler, RefObject } from 'react';
+import type { Action, Store } from "redux";
+import type { InputState } from "@krutoo/input-mask/core";
+import type { InputProps } from "../input";
+import type {
+  ChangeEvent,
+  FocusEvent,
+  FormEvent,
+  FormEventHandler,
+  RefObject,
+} from "react";
 
 export interface InputMaskReactOptions {
   /** Строковое представление маски. */
@@ -15,9 +21,9 @@ export interface InputMaskReactOptions {
 }
 
 export interface MaskedInputProps
-  extends Omit<InputProps, 'onFocus' | 'onChange' | 'onBlur' | 'onInput'>,
-    Pick<InputMaskReactOptions, 'mask'>,
-    Partial<Omit<InputMaskReactOptions, 'mask'>> {
+  extends Omit<InputProps, "onFocus" | "onChange" | "onBlur" | "onInput">,
+    Pick<InputMaskReactOptions, "mask">,
+    Partial<Omit<InputMaskReactOptions, "mask">> {
   /** Сработает при фокусе. Вторым аргументом получит данные поля с маской. */
   onFocus?: (event: FocusEvent<HTMLInputElement>, data: MaskData) => void;
 
@@ -29,6 +35,9 @@ export interface MaskedInputProps
 
   /** Сработает при "blur". Вторым аргументом получит данные поля с маской. */
   onBlur?: (event: FocusEvent<HTMLInputElement>, data: MaskData) => void;
+
+  /** Минимальное допустимое количество символов для расчета заполненности маски. */
+  filledMaskMinLength?: number;
 }
 
 export interface MaskData {

--- a/src/masked-input/types.ts
+++ b/src/masked-input/types.ts
@@ -1,13 +1,7 @@
-import type { Action, Store } from "redux";
-import type { InputState } from "@krutoo/input-mask/core";
-import type { InputProps } from "../input";
-import type {
-  ChangeEvent,
-  FocusEvent,
-  FormEvent,
-  FormEventHandler,
-  RefObject,
-} from "react";
+import type { Action, Store } from 'redux';
+import type { InputState } from '@krutoo/input-mask/core';
+import type { InputProps } from '../input';
+import type { ChangeEvent, FocusEvent, FormEvent, FormEventHandler, RefObject } from 'react';
 
 export interface InputMaskReactOptions {
   /** Строковое представление маски. */
@@ -21,9 +15,9 @@ export interface InputMaskReactOptions {
 }
 
 export interface MaskedInputProps
-  extends Omit<InputProps, "onFocus" | "onChange" | "onBlur" | "onInput">,
-    Pick<InputMaskReactOptions, "mask">,
-    Partial<Omit<InputMaskReactOptions, "mask">> {
+  extends Omit<InputProps, 'onFocus' | 'onChange' | 'onBlur' | 'onInput'>,
+    Pick<InputMaskReactOptions, 'mask'>,
+    Partial<Omit<InputMaskReactOptions, 'mask'>> {
   /** Сработает при фокусе. Вторым аргументом получит данные поля с маской. */
   onFocus?: (event: FocusEvent<HTMLInputElement>, data: MaskData) => void;
 

--- a/src/phone-input/__test__/phone-input.test.tsx
+++ b/src/phone-input/__test__/phone-input.test.tsx
@@ -1,165 +1,119 @@
-import { ChangeEvent, createRef } from "react";
+import { ChangeEvent, createRef } from 'react';
 import {
   createEvent,
   fireEvent,
   getByTestId,
   queryAllByTestId,
   render,
-} from "@testing-library/react";
-import { PhoneInput } from "../phone-input";
-import { MaskData } from "../../masked-input";
-import userEvent from "@testing-library/user-event";
+} from '@testing-library/react';
+import { PhoneInput } from '../phone-input';
+import { MaskData } from '../../masked-input';
+import userEvent from '@testing-library/user-event';
 
-describe("PhoneInput", () => {
-  it("render input with opener and russia mask by default", () => {
-    const { container } = render(<PhoneInput value="" onChange={jest.fn()} />);
+describe('PhoneInput', () => {
+  it('render input with opener and russia mask by default', () => {
+    const { container } = render(<PhoneInput value='' onChange={jest.fn()} />);
 
-    expect(queryAllByTestId(container, "phone-input")).toHaveLength(1);
-    expect(queryAllByTestId(container, "phone-input:menu-opener")).toHaveLength(
-      1,
-    );
-    expect(
-      getByTestId<HTMLInputElement>(container, "base-input:field").value,
-    ).toBe("+7 (");
-    expect(getByTestId(container, "rest-placeholder-shift").textContent).toBe(
-      "+7 (",
-    );
-    expect(getByTestId(container, "rest-placeholder").textContent).toBe(
-      "___) ___-__-__",
-    );
-    expect(getByTestId(container, "field-block:label").textContent).toBe(
-      "Телефон",
-    );
+    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
+    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('+7 (');
+    expect(getByTestId(container, 'rest-placeholder-shift').textContent).toBe('+7 (');
+    expect(getByTestId(container, 'rest-placeholder').textContent).toBe('___) ___-__-__');
+    expect(getByTestId(container, 'field-block:label').textContent).toBe('Телефон');
   });
 
   it('handle "defaultValue" prop properly', () => {
-    const expected = "+7 (999) 888-77-66";
+    const expected = '+7 (999) 888-77-66';
 
-    const { container, rerender } = render(
-      <PhoneInput defaultValue="79998887766" />,
-    );
-    expect(
-      getByTestId<HTMLInputElement>(container, "base-input:field").value,
-    ).toBe(expected);
+    const { container, rerender } = render(<PhoneInput defaultValue='79998887766' />);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
 
-    rerender(<PhoneInput defaultValue="71112223344" />);
-    expect(
-      getByTestId<HTMLInputElement>(container, "base-input:field").value,
-    ).toBe(expected);
+    rerender(<PhoneInput defaultValue='71112223344' />);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
   });
 
-  it("open/close menu by opener click", () => {
-    const { baseElement, container } = render(
-      <PhoneInput value="" onChange={jest.fn()} />,
-    );
+  it('open/close menu by opener click', () => {
+    const { baseElement, container } = render(<PhoneInput value='' onChange={jest.fn()} />);
 
-    expect(queryAllByTestId(container, "phone-input")).toHaveLength(1);
-    expect(queryAllByTestId(container, "phone-input:menu-opener")).toHaveLength(
-      1,
-    );
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
+    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
 
-    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
 
-    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
   });
 
-  it("reset value and change mask by select item from menu", () => {
-    const onChange = jest.fn(
-      (event: ChangeEvent, data: MaskData) => void [event, data],
-    );
+  it('reset value and change mask by select item from menu', () => {
+    const onChange = jest.fn((event: ChangeEvent, data: MaskData) => void [event, data]);
 
     const { baseElement, container } = render(
-      <PhoneInput defaultValue="998-22-333-4444" onChange={onChange} />,
+      <PhoneInput defaultValue='998-22-333-4444' onChange={onChange} />,
     );
 
-    expect(
-      getByTestId<HTMLInputElement>(container, "base-input:field").value,
-    ).toBe("+998-22-333-4444");
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(
+      '+998-22-333-4444',
+    );
 
     // open menu
-    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
-    expect(queryAllByTestId(baseElement, "dropdown-item")).toHaveLength(13);
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(13);
     expect(onChange).toHaveBeenCalledTimes(0);
 
     // select georgia
-    fireEvent.click(queryAllByTestId(baseElement, "dropdown-item")[6]);
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
-    expect(queryAllByTestId(baseElement, "dropdown-item")).toHaveLength(0);
+    fireEvent.click(queryAllByTestId(baseElement, 'dropdown-item')[6]);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(0);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange.mock.calls[0][1].value).toBe("+995 (");
-    expect(onChange.mock.calls[0][1].cleanValue).toBe("995");
+    expect(onChange.mock.calls[0][1].value).toBe('+995 (');
+    expect(onChange.mock.calls[0][1].cleanValue).toBe('995');
   });
 
-  it("field must be looks like focused when opener focused or menu opened", async () => {
+  it('field must be looks like focused when opener focused or menu opened', async () => {
     const user = userEvent.setup();
-    const { baseElement, container } = render(
-      <PhoneInput defaultValue="998-22-333-4444" />,
-    );
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(false);
+    const { baseElement, container } = render(<PhoneInput defaultValue='998-22-333-4444' />);
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
 
     // focus on input by click
-    await user.click(getByTestId(container, "base-input:field"));
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(true);
+    await user.click(getByTestId(container, 'base-input:field'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
 
     // focus on previous element
-    await user.keyboard("{Shift>}[Tab]{/Shift}");
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(false);
+    await user.keyboard('{Shift>}[Tab]{/Shift}');
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
 
     // focus on input
-    await user.keyboard("[Tab]");
-    expect(document.activeElement).toBe(
-      getByTestId(container, "base-input:field"),
-    );
+    await user.keyboard('[Tab]');
+    expect(document.activeElement).toBe(getByTestId(container, 'base-input:field'));
 
     // focus on menu opener
-    await user.keyboard("[Tab]");
-    expect(document.activeElement).toBe(
-      getByTestId(container, "phone-input:menu-opener"),
-    );
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(true);
+    await user.keyboard('[Tab]');
+    expect(document.activeElement).toBe(getByTestId(container, 'phone-input:menu-opener'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
 
     // focus on next element after menu opener
-    await user.keyboard("[Tab]");
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(false);
+    await user.keyboard('[Tab]');
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
 
     // click on menu opener
-    await user.click(getByTestId(container, "phone-input:menu-opener"));
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(true);
-    expect(document.activeElement).toBe(getByTestId(baseElement, "dropdown"));
+    await user.click(getByTestId(container, 'phone-input:menu-opener'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+    expect(document.activeElement).toBe(getByTestId(baseElement, 'dropdown'));
 
     // blur on menu
-    fireEvent.blur(getByTestId(baseElement, "dropdown"));
-    expect(
-      getByTestId(container, "phone-input").classList.contains("focused"),
-    ).toBe(false);
+    fireEvent.blur(getByTestId(baseElement, 'dropdown'));
+    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
   });
 
   it('should not show rest placeholder for "other" variant', () => {
-    const { container } = render(<PhoneInput defaultValue="1234567890" />);
+    const { container } = render(<PhoneInput defaultValue='1234567890' />);
 
-    expect(
-      getByTestId<HTMLInputElement>(container, "base-input:field").value,
-    ).toBe("1234567890");
-    expect(queryAllByTestId(container, "rest-placeholder-shift")).toHaveLength(
-      0,
-    );
-    expect(queryAllByTestId(container, "rest-placeholder")).toHaveLength(0);
+    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('1234567890');
+    expect(queryAllByTestId(container, 'rest-placeholder-shift')).toHaveLength(0);
+    expect(queryAllByTestId(container, 'rest-placeholder')).toHaveLength(0);
   });
 
   it('should handle "inputRef" prop', () => {
@@ -168,9 +122,7 @@ describe("PhoneInput", () => {
 
     const { container } = render(<PhoneInput inputRef={inputRef} />);
     expect(inputRef.current instanceof HTMLInputElement).toBe(true);
-    expect(
-      inputRef.current === getByTestId(container, "base-input:field"),
-    ).toBe(true);
+    expect(inputRef.current === getByTestId(container, 'base-input:field')).toBe(true);
   });
 
   it('should handle "blockRef" prop', () => {
@@ -179,180 +131,158 @@ describe("PhoneInput", () => {
 
     const { container } = render(<PhoneInput blockRef={blockRef} />);
     expect(blockRef.current instanceof HTMLDivElement).toBe(true);
-    expect(
-      blockRef.current === getByTestId(container, "field-block:block"),
-    ).toBe(true);
+    expect(blockRef.current === getByTestId(container, 'field-block:block')).toBe(true);
   });
 
-  it("should handle change event of masked input properly", () => {
+  it('should handle change event of masked input properly', () => {
     const onChange = jest.fn();
     const { container } = render(<PhoneInput onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    fireEvent.focus(getByTestId(container, "base-input:field"));
-    fireEvent.change(getByTestId(container, "base-input:field"), {
-      target: { value: "79992225511" },
+    fireEvent.focus(getByTestId(container, 'base-input:field'));
+    fireEvent.change(getByTestId(container, 'base-input:field'), {
+      target: { value: '79992225511' },
     });
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it("should handle onMenuOpen/onMenuClose", () => {
+  it('should handle onMenuOpen/onMenuClose', () => {
     const openSpy = jest.fn();
     const closeSpy = jest.fn();
 
     const { container, baseElement } = render(
       <PhoneInput onMenuOpen={openSpy} onMenuClose={closeSpy} />,
     );
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
     expect(openSpy).toHaveBeenCalledTimes(0);
     expect(closeSpy).toHaveBeenCalledTimes(0);
 
-    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(closeSpy).toHaveBeenCalledTimes(0);
 
-    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("should handle undefined as value during rerender", () => {
+  it('should handle undefined as value during rerender', () => {
     const spy = jest.fn();
 
-    const { rerender, container } = render(
-      <PhoneInput value="79990002211" onChange={spy} />,
+    const { rerender, container } = render(<PhoneInput value='79990002211' onChange={spy} />);
+
+    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe(
+      '+7 (999) 000-22-11',
     );
 
-    expect(
-      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
-    ).toBe("+7 (999) 000-22-11");
+    rerender(<PhoneInput value='71002003040' onChange={spy} />);
 
-    rerender(<PhoneInput value="71002003040" onChange={spy} />);
-
-    expect(
-      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
-    ).toBe("+7 (100) 200-30-40");
+    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe(
+      '+7 (100) 200-30-40',
+    );
 
     rerender(<PhoneInput value={undefined} onChange={spy} />);
 
-    expect(
-      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
-    ).toBe("+7 (");
+    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe('+7 (');
   });
 
-  it("should call onInput correctly", async () => {
+  it('should call onInput correctly', async () => {
     const spy = jest.fn();
-    const { container } = render(<PhoneInput defaultValue="7" onInput={spy} />);
+    const { container } = render(<PhoneInput defaultValue='7' onInput={spy} />);
 
-    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
+    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
 
-    expect(input.value).toBe("+7 (");
+    expect(input.value).toBe('+7 (');
     expect(spy).toHaveBeenCalledTimes(0);
 
-    await userEvent.type(input, "8005553535");
+    await userEvent.type(input, '8005553535');
 
-    expect(input.value).toBe("+7 (800) 555-35-35");
+    expect(input.value).toBe('+7 (800) 555-35-35');
     expect(spy).toHaveBeenCalledTimes(10);
   });
 
-  it("should handle disabled", async () => {
+  it('should handle disabled', async () => {
     const { container: root, baseElement: base } = render(
-      <PhoneInput defaultValue="7" onChange={jest.fn()} disabled />,
+      <PhoneInput defaultValue='7' onChange={jest.fn()} disabled />,
     );
 
-    expect(getByTestId(root, "base-input:field").hasAttribute("disabled")).toBe(
-      true,
-    );
-    expect(
-      getByTestId(root, "phone-input:menu-opener").getAttribute(
-        "aria-disabled",
-      ),
-    ).toBe("true");
+    expect(getByTestId(root, 'base-input:field').hasAttribute('disabled')).toBe(true);
+    expect(getByTestId(root, 'phone-input:menu-opener').getAttribute('aria-disabled')).toBe('true');
 
-    await userEvent.click(getByTestId(root, "phone-input"));
-    expect(
-      getByTestId(root, "base-input:field") === document.activeElement,
-    ).toBe(false);
+    await userEvent.click(getByTestId(root, 'phone-input'));
+    expect(getByTestId(root, 'base-input:field') === document.activeElement).toBe(false);
 
-    await userEvent.click(getByTestId(root, "phone-input:menu-opener"));
-    expect(queryAllByTestId(base, "dropdown")).toHaveLength(0);
-    expect(queryAllByTestId(base, "dropdown-item")).toHaveLength(0);
+    await userEvent.click(getByTestId(root, 'phone-input:menu-opener'));
+    expect(queryAllByTestId(base, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(base, 'dropdown-item')).toHaveLength(0);
   });
 
-  it("should select first mask when getDefaultMask returns undefined", () => {
+  it('should select first mask when getDefaultMask returns undefined', () => {
     const { container } = render(
       <PhoneInput
-        defaultValue="12345"
+        defaultValue='12345'
         getDefaultMask={() => undefined}
         masks={[
           {
-            id: "armenia",
-            title: "Foo",
-            mask: "+1____",
-            optionImageSrc: "",
+            id: 'armenia',
+            title: 'Foo',
+            mask: '+1____',
+            optionImageSrc: '',
           },
           {
-            id: "azerbaijan",
-            title: "Bar",
-            mask: "+2____",
-            optionImageSrc: "",
+            id: 'azerbaijan',
+            title: 'Bar',
+            mask: '+2____',
+            optionImageSrc: '',
           },
           {
-            id: "belarus",
-            title: "Baz",
-            mask: "+3____",
-            optionImageSrc: "",
+            id: 'belarus',
+            title: 'Baz',
+            mask: '+3____',
+            optionImageSrc: '',
           },
         ]}
       />,
     );
 
-    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
-    expect(input.value).toBe("+12345");
+    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
+    expect(input.value).toBe('+12345');
   });
 
-  it("should select stub mask when getDefaultMask returns undefined and mask is empty", () => {
+  it('should select stub mask when getDefaultMask returns undefined and mask is empty', () => {
     const { container } = render(
-      <PhoneInput
-        defaultValue="12345"
-        getDefaultMask={() => undefined}
-        masks={[]}
-      />,
+      <PhoneInput defaultValue='12345' getDefaultMask={() => undefined} masks={[]} />,
     );
 
-    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
-    expect(input.value).toBe("12345");
+    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
+    expect(input.value).toBe('12345');
   });
 
-  it("should open menu by menu opener keydown", () => {
-    const { container, baseElement } = render(
-      <PhoneInput defaultValue="78005553535" />,
-    );
-    const opener = getByTestId(container, "phone-input:menu-opener");
+  it('should open menu by menu opener keydown', () => {
+    const { container, baseElement } = render(<PhoneInput defaultValue='78005553535' />);
+    const opener = getByTestId(container, 'phone-input:menu-opener');
 
     // initial state
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
 
     // enter keydown on opener
-    fireEvent.keyDown(opener, { code: "Enter" });
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
+    fireEvent.keyDown(opener, { code: 'Enter' });
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
   });
 
-  it("should not open menu by menu opener keydown when event is default prevented", () => {
-    const { container, baseElement } = render(
-      <PhoneInput defaultValue="78005553535" />,
-    );
-    const opener = getByTestId(container, "phone-input:menu-opener");
+  it('should not open menu by menu opener keydown when event is default prevented', () => {
+    const { container, baseElement } = render(<PhoneInput defaultValue='78005553535' />);
+    const opener = getByTestId(container, 'phone-input:menu-opener');
 
     // initial state
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
 
     // enter keydown on opener
     const event = createEvent.keyDown(opener);
     event.preventDefault();
     opener.dispatchEvent(event);
-    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
   });
 });

--- a/src/phone-input/__test__/phone-input.test.tsx
+++ b/src/phone-input/__test__/phone-input.test.tsx
@@ -1,119 +1,165 @@
-import { ChangeEvent, createRef } from 'react';
+import { ChangeEvent, createRef } from "react";
 import {
   createEvent,
   fireEvent,
   getByTestId,
   queryAllByTestId,
   render,
-} from '@testing-library/react';
-import { PhoneInput } from '../phone-input';
-import { MaskData } from '../../masked-input';
-import userEvent from '@testing-library/user-event';
+} from "@testing-library/react";
+import { PhoneInput } from "../phone-input";
+import { MaskData } from "../../masked-input";
+import userEvent from "@testing-library/user-event";
 
-describe('PhoneInput', () => {
-  it('render input with opener and russia mask by default', () => {
-    const { container } = render(<PhoneInput value='' onChange={jest.fn()} />);
+describe("PhoneInput", () => {
+  it("render input with opener and russia mask by default", () => {
+    const { container } = render(<PhoneInput value="" onChange={jest.fn()} />);
 
-    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
-    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
-    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('+7 (');
-    expect(getByTestId(container, 'rest-placeholder-shift').textContent).toBe('+7 (');
-    expect(getByTestId(container, 'rest-placeholder').textContent).toBe('___) ___-__-__');
-    expect(getByTestId(container, 'field-block:label').textContent).toBe('Телефон');
+    expect(queryAllByTestId(container, "phone-input")).toHaveLength(1);
+    expect(queryAllByTestId(container, "phone-input:menu-opener")).toHaveLength(
+      1,
+    );
+    expect(
+      getByTestId<HTMLInputElement>(container, "base-input:field").value,
+    ).toBe("+7 (");
+    expect(getByTestId(container, "rest-placeholder-shift").textContent).toBe(
+      "+7 (",
+    );
+    expect(getByTestId(container, "rest-placeholder").textContent).toBe(
+      "___) ___-__-__",
+    );
+    expect(getByTestId(container, "field-block:label").textContent).toBe(
+      "Телефон",
+    );
   });
 
   it('handle "defaultValue" prop properly', () => {
-    const expected = '+7 (999) 888-77-66';
+    const expected = "+7 (999) 888-77-66";
 
-    const { container, rerender } = render(<PhoneInput defaultValue='79998887766' />);
-    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
+    const { container, rerender } = render(
+      <PhoneInput defaultValue="79998887766" />,
+    );
+    expect(
+      getByTestId<HTMLInputElement>(container, "base-input:field").value,
+    ).toBe(expected);
 
-    rerender(<PhoneInput defaultValue='71112223344' />);
-    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(expected);
+    rerender(<PhoneInput defaultValue="71112223344" />);
+    expect(
+      getByTestId<HTMLInputElement>(container, "base-input:field").value,
+    ).toBe(expected);
   });
 
-  it('open/close menu by opener click', () => {
-    const { baseElement, container } = render(<PhoneInput value='' onChange={jest.fn()} />);
+  it("open/close menu by opener click", () => {
+    const { baseElement, container } = render(
+      <PhoneInput value="" onChange={jest.fn()} />,
+    );
 
-    expect(queryAllByTestId(container, 'phone-input')).toHaveLength(1);
-    expect(queryAllByTestId(container, 'phone-input:menu-opener')).toHaveLength(1);
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(container, "phone-input")).toHaveLength(1);
+    expect(queryAllByTestId(container, "phone-input:menu-opener")).toHaveLength(
+      1,
+    );
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
 
-    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
 
-    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
   });
 
-  it('reset value and change mask by select item from menu', () => {
-    const onChange = jest.fn((event: ChangeEvent, data: MaskData) => void [event, data]);
+  it("reset value and change mask by select item from menu", () => {
+    const onChange = jest.fn(
+      (event: ChangeEvent, data: MaskData) => void [event, data],
+    );
 
     const { baseElement, container } = render(
-      <PhoneInput defaultValue='998-22-333-4444' onChange={onChange} />,
+      <PhoneInput defaultValue="998-22-333-4444" onChange={onChange} />,
     );
 
-    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe(
-      '+998-22-333-4444',
-    );
+    expect(
+      getByTestId<HTMLInputElement>(container, "base-input:field").value,
+    ).toBe("+998-22-333-4444");
 
     // open menu
-    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
-    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(13);
+    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
+    expect(queryAllByTestId(baseElement, "dropdown-item")).toHaveLength(13);
     expect(onChange).toHaveBeenCalledTimes(0);
 
     // select georgia
-    fireEvent.click(queryAllByTestId(baseElement, 'dropdown-item')[6]);
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
-    expect(queryAllByTestId(baseElement, 'dropdown-item')).toHaveLength(0);
+    fireEvent.click(queryAllByTestId(baseElement, "dropdown-item")[6]);
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, "dropdown-item")).toHaveLength(0);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange.mock.calls[0][1].value).toBe('+995 (');
-    expect(onChange.mock.calls[0][1].cleanValue).toBe('995');
+    expect(onChange.mock.calls[0][1].value).toBe("+995 (");
+    expect(onChange.mock.calls[0][1].cleanValue).toBe("995");
   });
 
-  it('field must be looks like focused when opener focused or menu opened', async () => {
+  it("field must be looks like focused when opener focused or menu opened", async () => {
     const user = userEvent.setup();
-    const { baseElement, container } = render(<PhoneInput defaultValue='998-22-333-4444' />);
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+    const { baseElement, container } = render(
+      <PhoneInput defaultValue="998-22-333-4444" />,
+    );
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(false);
 
     // focus on input by click
-    await user.click(getByTestId(container, 'base-input:field'));
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+    await user.click(getByTestId(container, "base-input:field"));
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(true);
 
     // focus on previous element
-    await user.keyboard('{Shift>}[Tab]{/Shift}');
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+    await user.keyboard("{Shift>}[Tab]{/Shift}");
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(false);
 
     // focus on input
-    await user.keyboard('[Tab]');
-    expect(document.activeElement).toBe(getByTestId(container, 'base-input:field'));
+    await user.keyboard("[Tab]");
+    expect(document.activeElement).toBe(
+      getByTestId(container, "base-input:field"),
+    );
 
     // focus on menu opener
-    await user.keyboard('[Tab]');
-    expect(document.activeElement).toBe(getByTestId(container, 'phone-input:menu-opener'));
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
+    await user.keyboard("[Tab]");
+    expect(document.activeElement).toBe(
+      getByTestId(container, "phone-input:menu-opener"),
+    );
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(true);
 
     // focus on next element after menu opener
-    await user.keyboard('[Tab]');
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+    await user.keyboard("[Tab]");
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(false);
 
     // click on menu opener
-    await user.click(getByTestId(container, 'phone-input:menu-opener'));
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(true);
-    expect(document.activeElement).toBe(getByTestId(baseElement, 'dropdown'));
+    await user.click(getByTestId(container, "phone-input:menu-opener"));
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(true);
+    expect(document.activeElement).toBe(getByTestId(baseElement, "dropdown"));
 
     // blur on menu
-    fireEvent.blur(getByTestId(baseElement, 'dropdown'));
-    expect(getByTestId(container, 'phone-input').classList.contains('focused')).toBe(false);
+    fireEvent.blur(getByTestId(baseElement, "dropdown"));
+    expect(
+      getByTestId(container, "phone-input").classList.contains("focused"),
+    ).toBe(false);
   });
 
   it('should not show rest placeholder for "other" variant', () => {
-    const { container } = render(<PhoneInput defaultValue='1234567890' />);
+    const { container } = render(<PhoneInput defaultValue="1234567890" />);
 
-    expect(getByTestId<HTMLInputElement>(container, 'base-input:field').value).toBe('1234567890');
-    expect(queryAllByTestId(container, 'rest-placeholder-shift')).toHaveLength(0);
-    expect(queryAllByTestId(container, 'rest-placeholder')).toHaveLength(0);
+    expect(
+      getByTestId<HTMLInputElement>(container, "base-input:field").value,
+    ).toBe("1234567890");
+    expect(queryAllByTestId(container, "rest-placeholder-shift")).toHaveLength(
+      0,
+    );
+    expect(queryAllByTestId(container, "rest-placeholder")).toHaveLength(0);
   });
 
   it('should handle "inputRef" prop', () => {
@@ -122,7 +168,9 @@ describe('PhoneInput', () => {
 
     const { container } = render(<PhoneInput inputRef={inputRef} />);
     expect(inputRef.current instanceof HTMLInputElement).toBe(true);
-    expect(inputRef.current === getByTestId(container, 'base-input:field')).toBe(true);
+    expect(
+      inputRef.current === getByTestId(container, "base-input:field"),
+    ).toBe(true);
   });
 
   it('should handle "blockRef" prop', () => {
@@ -131,155 +179,180 @@ describe('PhoneInput', () => {
 
     const { container } = render(<PhoneInput blockRef={blockRef} />);
     expect(blockRef.current instanceof HTMLDivElement).toBe(true);
-    expect(blockRef.current === getByTestId(container, 'field-block:block')).toBe(true);
+    expect(
+      blockRef.current === getByTestId(container, "field-block:block"),
+    ).toBe(true);
   });
 
-  it('should handle change event of masked input properly', () => {
+  it("should handle change event of masked input properly", () => {
     const onChange = jest.fn();
     const { container } = render(<PhoneInput onChange={onChange} />);
 
     expect(onChange).toHaveBeenCalledTimes(0);
-    fireEvent.focus(getByTestId(container, 'base-input:field'));
-    fireEvent.change(getByTestId(container, 'base-input:field'), {
-      target: { value: '79992225511' },
+    fireEvent.focus(getByTestId(container, "base-input:field"));
+    fireEvent.change(getByTestId(container, "base-input:field"), {
+      target: { value: "79992225511" },
     });
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle onMenuOpen/onMenuClose', () => {
+  it("should handle onMenuOpen/onMenuClose", () => {
     const openSpy = jest.fn();
     const closeSpy = jest.fn();
 
     const { container, baseElement } = render(
       <PhoneInput onMenuOpen={openSpy} onMenuClose={closeSpy} />,
     );
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
     expect(openSpy).toHaveBeenCalledTimes(0);
     expect(closeSpy).toHaveBeenCalledTimes(0);
 
-    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(closeSpy).toHaveBeenCalledTimes(0);
 
-    fireEvent.mouseDown(getByTestId(container, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    fireEvent.mouseDown(getByTestId(container, "phone-input:menu-opener"));
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle undefined as value during rerender', () => {
+  it("should handle undefined as value during rerender", () => {
     const spy = jest.fn();
 
-    const { rerender, container } = render(<PhoneInput value='79990002211' onChange={spy} />);
-
-    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe(
-      '+7 (999) 000-22-11',
+    const { rerender, container } = render(
+      <PhoneInput value="79990002211" onChange={spy} />,
     );
 
-    rerender(<PhoneInput value='71002003040' onChange={spy} />);
+    expect(
+      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
+    ).toBe("+7 (999) 000-22-11");
 
-    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe(
-      '+7 (100) 200-30-40',
-    );
+    rerender(<PhoneInput value="71002003040" onChange={spy} />);
+
+    expect(
+      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
+    ).toBe("+7 (100) 200-30-40");
 
     rerender(<PhoneInput value={undefined} onChange={spy} />);
 
-    expect((getByTestId(container, 'base-input:field') as HTMLInputElement).value).toBe('+7 (');
+    expect(
+      (getByTestId(container, "base-input:field") as HTMLInputElement).value,
+    ).toBe("+7 (");
   });
 
-  it('should call onInput correctly', async () => {
+  it("should call onInput correctly", async () => {
     const spy = jest.fn();
-    const { container } = render(<PhoneInput defaultValue='7' onInput={spy} />);
+    const { container } = render(<PhoneInput defaultValue="7" onInput={spy} />);
 
-    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
+    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
 
-    expect(input.value).toBe('+7 (');
+    expect(input.value).toBe("+7 (");
     expect(spy).toHaveBeenCalledTimes(0);
 
-    await userEvent.type(input, '8005553535');
+    await userEvent.type(input, "8005553535");
 
-    expect(input.value).toBe('+7 (800) 555-35-35');
+    expect(input.value).toBe("+7 (800) 555-35-35");
     expect(spy).toHaveBeenCalledTimes(10);
   });
 
-  it('should handle disabled', async () => {
+  it("should handle disabled", async () => {
     const { container: root, baseElement: base } = render(
-      <PhoneInput defaultValue='7' onChange={jest.fn()} disabled />,
+      <PhoneInput defaultValue="7" onChange={jest.fn()} disabled />,
     );
 
-    expect(getByTestId(root, 'base-input:field').hasAttribute('disabled')).toBe(true);
-    expect(getByTestId(root, 'phone-input:menu-opener').getAttribute('aria-disabled')).toBe('true');
+    expect(getByTestId(root, "base-input:field").hasAttribute("disabled")).toBe(
+      true,
+    );
+    expect(
+      getByTestId(root, "phone-input:menu-opener").getAttribute(
+        "aria-disabled",
+      ),
+    ).toBe("true");
 
-    await userEvent.click(getByTestId(root, 'phone-input'));
-    expect(getByTestId(root, 'base-input:field') === document.activeElement).toBe(false);
+    await userEvent.click(getByTestId(root, "phone-input"));
+    expect(
+      getByTestId(root, "base-input:field") === document.activeElement,
+    ).toBe(false);
 
-    await userEvent.click(getByTestId(root, 'phone-input:menu-opener'));
-    expect(queryAllByTestId(base, 'dropdown')).toHaveLength(0);
-    expect(queryAllByTestId(base, 'dropdown-item')).toHaveLength(0);
+    await userEvent.click(getByTestId(root, "phone-input:menu-opener"));
+    expect(queryAllByTestId(base, "dropdown")).toHaveLength(0);
+    expect(queryAllByTestId(base, "dropdown-item")).toHaveLength(0);
   });
 
-  it('should select first mask when getDefaultMask returns undefined', () => {
+  it("should select first mask when getDefaultMask returns undefined", () => {
     const { container } = render(
       <PhoneInput
-        defaultValue='12345'
+        defaultValue="12345"
         getDefaultMask={() => undefined}
         masks={[
           {
-            id: 'foo',
-            title: 'Foo',
-            mask: '+1____',
+            id: "armenia",
+            title: "Foo",
+            mask: "+1____",
+            optionImageSrc: "",
           },
           {
-            id: 'bar',
-            title: 'Bar',
-            mask: '+2____',
+            id: "azerbaijan",
+            title: "Bar",
+            mask: "+2____",
+            optionImageSrc: "",
           },
           {
-            id: 'baz',
-            title: 'Baz',
-            mask: '+3____',
+            id: "belarus",
+            title: "Baz",
+            mask: "+3____",
+            optionImageSrc: "",
           },
         ]}
       />,
     );
 
-    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
-    expect(input.value).toBe('+12345');
+    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
+    expect(input.value).toBe("+12345");
   });
 
-  it('should select stub mask when getDefaultMask returns undefined and mask is empty', () => {
+  it("should select stub mask when getDefaultMask returns undefined and mask is empty", () => {
     const { container } = render(
-      <PhoneInput defaultValue='12345' getDefaultMask={() => undefined} masks={[]} />,
+      <PhoneInput
+        defaultValue="12345"
+        getDefaultMask={() => undefined}
+        masks={[]}
+      />,
     );
 
-    const input = getByTestId<HTMLInputElement>(container, 'base-input:field');
-    expect(input.value).toBe('12345');
+    const input = getByTestId<HTMLInputElement>(container, "base-input:field");
+    expect(input.value).toBe("12345");
   });
 
-  it('should open menu by menu opener keydown', () => {
-    const { container, baseElement } = render(<PhoneInput defaultValue='78005553535' />);
-    const opener = getByTestId(container, 'phone-input:menu-opener');
+  it("should open menu by menu opener keydown", () => {
+    const { container, baseElement } = render(
+      <PhoneInput defaultValue="78005553535" />,
+    );
+    const opener = getByTestId(container, "phone-input:menu-opener");
 
     // initial state
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
 
     // enter keydown on opener
-    fireEvent.keyDown(opener, { code: 'Enter' });
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(1);
+    fireEvent.keyDown(opener, { code: "Enter" });
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(1);
   });
 
-  it('should not open menu by menu opener keydown when event is default prevented', () => {
-    const { container, baseElement } = render(<PhoneInput defaultValue='78005553535' />);
-    const opener = getByTestId(container, 'phone-input:menu-opener');
+  it("should not open menu by menu opener keydown when event is default prevented", () => {
+    const { container, baseElement } = render(
+      <PhoneInput defaultValue="78005553535" />,
+    );
+    const opener = getByTestId(container, "phone-input:menu-opener");
 
     // initial state
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
 
     // enter keydown on opener
     const event = createEvent.keyDown(opener);
     event.preventDefault();
     opener.dispatchEvent(event);
-    expect(queryAllByTestId(baseElement, 'dropdown')).toHaveLength(0);
+    expect(queryAllByTestId(baseElement, "dropdown")).toHaveLength(0);
   });
 });

--- a/src/phone-input/index.ts
+++ b/src/phone-input/index.ts
@@ -1,4 +1,4 @@
-export type { PhoneInputProps, PhoneInputMask, MaskId } from "./types";
-export { PhoneInput } from "./phone-input";
-export { defaultGetDefaultMask, PhoneValue } from "./utils";
-export * from "./preset/defaults";
+export type { PhoneInputProps, PhoneInputMask, MaskId } from './types';
+export { PhoneInput } from './phone-input';
+export { defaultGetDefaultMask, PhoneValue } from './utils';
+export * from './preset/defaults';

--- a/src/phone-input/index.ts
+++ b/src/phone-input/index.ts
@@ -1,4 +1,4 @@
-export type { PhoneInputProps } from './types';
-export { PhoneInput } from './phone-input';
-export { defaultGetDefaultMask, PhoneValue } from './utils';
-export * from './preset/defaults';
+export type { PhoneInputProps, PhoneInputMask, MaskId } from "./types";
+export { PhoneInput } from "./phone-input";
+export { defaultGetDefaultMask, PhoneValue } from "./utils";
+export * from "./preset/defaults";

--- a/src/phone-input/phone-input.tsx
+++ b/src/phone-input/phone-input.tsx
@@ -1,16 +1,27 @@
-import { useState, useCallback, useRef, useContext, useMemo, useImperativeHandle } from 'react';
-import { type PhoneInputProps, type PhoneInputMask } from './types';
-import { type MaskData, type MaskedInputProps, MaskedInput } from '../masked-input';
-import { masks as defaultMasks, stubMask } from './preset/defaults';
-import { PhoneValue, defaultGetDefaultMask, stubSyntheticEvent } from './utils';
-import { Select } from '../select';
-import { DropdownItem } from '../dropdown-item';
-import { SelectContext } from '../select/utils';
-import { PhoneInputMenuOpener } from './menu-opener';
-import { useIsomorphicLayoutEffect } from '../hooks';
-import { mergeRefs } from '../helpers';
-import classNames from 'classnames/bind';
-import styles from './phone-input.m.scss';
+import {
+  useState,
+  useCallback,
+  useRef,
+  useContext,
+  useMemo,
+  useImperativeHandle,
+} from "react";
+import { type PhoneInputProps, type PhoneInputMask } from "./types";
+import {
+  type MaskData,
+  type MaskedInputProps,
+  MaskedInput,
+} from "../masked-input";
+import { masks as defaultMasks, stubMask } from "./preset/defaults";
+import { PhoneValue, defaultGetDefaultMask, stubSyntheticEvent } from "./utils";
+import { Select } from "../select";
+import { DropdownItem } from "../dropdown-item";
+import { SelectContext } from "../select/utils";
+import { PhoneInputMenuOpener } from "./menu-opener";
+import { useIsomorphicLayoutEffect } from "../hooks";
+import { mergeRefs } from "../helpers";
+import classNames from "classnames/bind";
+import styles from "./phone-input.m.scss";
 
 const cx = classNames.bind(styles);
 
@@ -27,16 +38,21 @@ export function PhoneInput({
   ...restProps
 }: PhoneInputProps) {
   const initialValueRef = useRef(value);
-  const stateless = useMemo(() => typeof initialValueRef.current !== 'undefined', []);
+  const stateless = useMemo(
+    () => typeof initialValueRef.current !== "undefined",
+    [],
+  );
 
   // ВАЖНО: при defaultValue состояние должно быть именно здесь (на уровень выше хука маски) для корректной работы
-  const [currentValue, setCurrentValue] = useState<string>(() => value ?? defaultValue ?? '');
+  const [currentValue, setCurrentValue] = useState<string>(
+    () => value ?? defaultValue ?? "",
+  );
 
   if (stateless) {
     return (
       <StatelessPhoneInput
         {...restProps}
-        value={value ?? ''}
+        value={value ?? ""}
         onChange={onChange}
         onInput={onInput}
       />
@@ -69,7 +85,7 @@ function StatelessPhoneInput({
   masks = defaultMasks,
   getDefaultMask = defaultGetDefaultMask,
   value,
-  label = 'Телефон',
+  label = "Телефон",
   inputRef: inputRefProp,
   onInput,
   onChange,
@@ -80,16 +96,19 @@ function StatelessPhoneInput({
   dropdownProps,
   onMenuOpen,
   onMenuClose,
-  'data-testid': testId = 'phone-input',
+  "data-testid": testId = "phone-input",
+  filledMaskMinLength,
   ...restProps
-}: Omit<PhoneInputProps, 'value' | 'defaultValue'> & { value: string }) {
+}: Omit<PhoneInputProps, "value" | "defaultValue"> & { value: string }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const wasMaskChosenRef = useRef<boolean>(false);
 
   const [mask, setMask] = useState<PhoneInputMask>(
     () => getDefaultMask({ value, masks }) ?? masks[0] ?? stubMask,
   );
-  const [plainValue, setPlainValue] = useState(() => PhoneValue.removeCode(value, mask));
+  const [plainValue, setPlainValue] = useState(() =>
+    PhoneValue.removeCode(value, mask),
+  );
 
   const getPhoneMaskData = useCallback(
     (maskData: MaskData): MaskData => ({
@@ -103,7 +122,7 @@ function StatelessPhoneInput({
   const handleMaskSelect = useCallback(
     (nextMask: PhoneInputMask) => {
       setMask(nextMask);
-      setPlainValue('');
+      setPlainValue("");
       wasMaskChosenRef.current = true;
     },
     [masks],
@@ -131,7 +150,7 @@ function StatelessPhoneInput({
 
     wasMaskChosenRef.current = false;
 
-    const syntheticEvent = stubSyntheticEvent(input, new Event('input'));
+    const syntheticEvent = stubSyntheticEvent(input, new Event("input"));
 
     const maskData: MaskData = {
       value: input.value,
@@ -156,9 +175,11 @@ function StatelessPhoneInput({
           withMenuOpener={masks.length > 1}
           currentMaskData={mask}
           mask={mask.mask}
+          filledMaskMinLength={filledMaskMinLength ?? mask.filledMaskMinLength}
           value={plainValue}
           baseInputProps={{
-            restPlaceholder: (mask.needRestPlaceholder ?? true) ? undefined : '',
+            restPlaceholder:
+              (mask.needRestPlaceholder ?? true) ? undefined : "",
             ...restProps.baseInputProps,
           }}
           onFocus={(event, maskData) => {
@@ -177,8 +198,8 @@ function StatelessPhoneInput({
           }}
         />
       }
-      onValueChange={maskId => {
-        const foundMask = masks.find(item => item.id === maskId);
+      onValueChange={(maskId) => {
+        const foundMask = masks.find((item) => item.id === maskId);
         foundMask && handleMaskSelect(foundMask);
       }}
       dropdownProps={dropdownProps}
@@ -186,19 +207,19 @@ function StatelessPhoneInput({
       onMenuClose={onMenuClose}
       disabled={disabled}
     >
-      {masks.map(item => (
+      {masks.map((item) => (
         <DropdownItem
           key={item.id}
           value={item.id}
-          size='m'
+          size="m"
           selected={item.id === mask.id}
           startContent={
             <img
-              alt=''
+              alt=""
               width={24}
               height={24}
               src={item.optionImageSrc}
-              className={cx('option-icon')}
+              className={cx("option-icon")}
             />
           }
           endContent={item.optionEndContent}
@@ -226,7 +247,8 @@ function PhoneMaskedInput({
   withMenuOpener: boolean;
   currentMaskData: PhoneInputMask;
 }) {
-  const { menuOpen, setMenuOpen, setOpenerElement, setAnchorElement } = useContext(SelectContext);
+  const { menuOpen, setMenuOpen, setOpenerElement, setAnchorElement } =
+    useContext(SelectContext);
 
   const [openerFocused, setOpenerFocused] = useState(false);
 
@@ -245,33 +267,33 @@ function PhoneMaskedInput({
       adornmentEnd={
         withMenuOpener && (
           <PhoneInputMenuOpener
-            className={cx('opener')}
+            className={cx("opener")}
             rootRef={setOpenerElement}
             imageSrc={currentMaskData.optionImageSrc}
             visuallyOpen={menuOpen}
             visuallyDisabled={disabled}
-            role='combobox'
-            aria-label='Выбор страны'
+            role="combobox"
+            aria-label="Выбор страны"
             aria-disabled={disabled}
             onBlur={() => setOpenerFocused(false)}
             onFocus={() => setOpenerFocused(true)}
             tabIndex={disabled ? undefined : 0}
-            onMouseDown={event => {
+            onMouseDown={(event) => {
               if (disabled || event.defaultPrevented) {
                 return;
               }
 
-              setMenuOpen(a => !a);
+              setMenuOpen((a) => !a);
             }}
-            onKeyDown={event => {
+            onKeyDown={(event) => {
               if (disabled || event.defaultPrevented) {
                 return;
               }
 
               switch (event.code) {
-                case 'Enter':
-                case 'ArrowUp':
-                case 'ArrowDown':
+                case "Enter":
+                case "ArrowUp":
+                case "ArrowDown":
                   setMenuOpen(true);
                   break;
               }

--- a/src/phone-input/phone-input.tsx
+++ b/src/phone-input/phone-input.tsx
@@ -1,27 +1,16 @@
-import {
-  useState,
-  useCallback,
-  useRef,
-  useContext,
-  useMemo,
-  useImperativeHandle,
-} from "react";
-import { type PhoneInputProps, type PhoneInputMask } from "./types";
-import {
-  type MaskData,
-  type MaskedInputProps,
-  MaskedInput,
-} from "../masked-input";
-import { masks as defaultMasks, stubMask } from "./preset/defaults";
-import { PhoneValue, defaultGetDefaultMask, stubSyntheticEvent } from "./utils";
-import { Select } from "../select";
-import { DropdownItem } from "../dropdown-item";
-import { SelectContext } from "../select/utils";
-import { PhoneInputMenuOpener } from "./menu-opener";
-import { useIsomorphicLayoutEffect } from "../hooks";
-import { mergeRefs } from "../helpers";
-import classNames from "classnames/bind";
-import styles from "./phone-input.m.scss";
+import { useState, useCallback, useRef, useContext, useMemo, useImperativeHandle } from 'react';
+import { type PhoneInputProps, type PhoneInputMask } from './types';
+import { type MaskData, type MaskedInputProps, MaskedInput } from '../masked-input';
+import { masks as defaultMasks, stubMask } from './preset/defaults';
+import { PhoneValue, defaultGetDefaultMask, stubSyntheticEvent } from './utils';
+import { Select } from '../select';
+import { DropdownItem } from '../dropdown-item';
+import { SelectContext } from '../select/utils';
+import { PhoneInputMenuOpener } from './menu-opener';
+import { useIsomorphicLayoutEffect } from '../hooks';
+import { mergeRefs } from '../helpers';
+import classNames from 'classnames/bind';
+import styles from './phone-input.m.scss';
 
 const cx = classNames.bind(styles);
 
@@ -38,21 +27,16 @@ export function PhoneInput({
   ...restProps
 }: PhoneInputProps) {
   const initialValueRef = useRef(value);
-  const stateless = useMemo(
-    () => typeof initialValueRef.current !== "undefined",
-    [],
-  );
+  const stateless = useMemo(() => typeof initialValueRef.current !== 'undefined', []);
 
   // ВАЖНО: при defaultValue состояние должно быть именно здесь (на уровень выше хука маски) для корректной работы
-  const [currentValue, setCurrentValue] = useState<string>(
-    () => value ?? defaultValue ?? "",
-  );
+  const [currentValue, setCurrentValue] = useState<string>(() => value ?? defaultValue ?? '');
 
   if (stateless) {
     return (
       <StatelessPhoneInput
         {...restProps}
-        value={value ?? ""}
+        value={value ?? ''}
         onChange={onChange}
         onInput={onInput}
       />
@@ -85,7 +69,7 @@ function StatelessPhoneInput({
   masks = defaultMasks,
   getDefaultMask = defaultGetDefaultMask,
   value,
-  label = "Телефон",
+  label = 'Телефон',
   inputRef: inputRefProp,
   onInput,
   onChange,
@@ -96,19 +80,17 @@ function StatelessPhoneInput({
   dropdownProps,
   onMenuOpen,
   onMenuClose,
-  "data-testid": testId = "phone-input",
+  'data-testid': testId = 'phone-input',
   filledMaskMinLength,
   ...restProps
-}: Omit<PhoneInputProps, "value" | "defaultValue"> & { value: string }) {
+}: Omit<PhoneInputProps, 'value' | 'defaultValue'> & { value: string }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const wasMaskChosenRef = useRef<boolean>(false);
 
   const [mask, setMask] = useState<PhoneInputMask>(
     () => getDefaultMask({ value, masks }) ?? masks[0] ?? stubMask,
   );
-  const [plainValue, setPlainValue] = useState(() =>
-    PhoneValue.removeCode(value, mask),
-  );
+  const [plainValue, setPlainValue] = useState(() => PhoneValue.removeCode(value, mask));
 
   const getPhoneMaskData = useCallback(
     (maskData: MaskData): MaskData => ({
@@ -122,7 +104,7 @@ function StatelessPhoneInput({
   const handleMaskSelect = useCallback(
     (nextMask: PhoneInputMask) => {
       setMask(nextMask);
-      setPlainValue("");
+      setPlainValue('');
       wasMaskChosenRef.current = true;
     },
     [masks],
@@ -150,7 +132,7 @@ function StatelessPhoneInput({
 
     wasMaskChosenRef.current = false;
 
-    const syntheticEvent = stubSyntheticEvent(input, new Event("input"));
+    const syntheticEvent = stubSyntheticEvent(input, new Event('input'));
 
     const maskData: MaskData = {
       value: input.value,
@@ -178,8 +160,7 @@ function StatelessPhoneInput({
           filledMaskMinLength={filledMaskMinLength ?? mask.filledMaskMinLength}
           value={plainValue}
           baseInputProps={{
-            restPlaceholder:
-              (mask.needRestPlaceholder ?? true) ? undefined : "",
+            restPlaceholder: (mask.needRestPlaceholder ?? true) ? undefined : '',
             ...restProps.baseInputProps,
           }}
           onFocus={(event, maskData) => {
@@ -198,8 +179,8 @@ function StatelessPhoneInput({
           }}
         />
       }
-      onValueChange={(maskId) => {
-        const foundMask = masks.find((item) => item.id === maskId);
+      onValueChange={maskId => {
+        const foundMask = masks.find(item => item.id === maskId);
         foundMask && handleMaskSelect(foundMask);
       }}
       dropdownProps={dropdownProps}
@@ -207,19 +188,19 @@ function StatelessPhoneInput({
       onMenuClose={onMenuClose}
       disabled={disabled}
     >
-      {masks.map((item) => (
+      {masks.map(item => (
         <DropdownItem
           key={item.id}
           value={item.id}
-          size="m"
+          size='m'
           selected={item.id === mask.id}
           startContent={
             <img
-              alt=""
+              alt=''
               width={24}
               height={24}
               src={item.optionImageSrc}
-              className={cx("option-icon")}
+              className={cx('option-icon')}
             />
           }
           endContent={item.optionEndContent}
@@ -247,8 +228,7 @@ function PhoneMaskedInput({
   withMenuOpener: boolean;
   currentMaskData: PhoneInputMask;
 }) {
-  const { menuOpen, setMenuOpen, setOpenerElement, setAnchorElement } =
-    useContext(SelectContext);
+  const { menuOpen, setMenuOpen, setOpenerElement, setAnchorElement } = useContext(SelectContext);
 
   const [openerFocused, setOpenerFocused] = useState(false);
 
@@ -267,33 +247,33 @@ function PhoneMaskedInput({
       adornmentEnd={
         withMenuOpener && (
           <PhoneInputMenuOpener
-            className={cx("opener")}
+            className={cx('opener')}
             rootRef={setOpenerElement}
             imageSrc={currentMaskData.optionImageSrc}
             visuallyOpen={menuOpen}
             visuallyDisabled={disabled}
-            role="combobox"
-            aria-label="Выбор страны"
+            role='combobox'
+            aria-label='Выбор страны'
             aria-disabled={disabled}
             onBlur={() => setOpenerFocused(false)}
             onFocus={() => setOpenerFocused(true)}
             tabIndex={disabled ? undefined : 0}
-            onMouseDown={(event) => {
+            onMouseDown={event => {
               if (disabled || event.defaultPrevented) {
                 return;
               }
 
-              setMenuOpen((a) => !a);
+              setMenuOpen(a => !a);
             }}
-            onKeyDown={(event) => {
+            onKeyDown={event => {
               if (disabled || event.defaultPrevented) {
                 return;
               }
 
               switch (event.code) {
-                case "Enter":
-                case "ArrowUp":
-                case "ArrowDown":
+                case 'Enter':
+                case 'ArrowUp':
+                case 'ArrowDown':
                   setMenuOpen(true);
                   break;
               }

--- a/src/phone-input/preset/defaults-import-png.ts
+++ b/src/phone-input/preset/defaults-import-png.ts
@@ -1,108 +1,109 @@
-import type { PhoneInputMask } from '../types';
-import russia from '../images/russia.png';
-import kazakhstan from '../images/kazakhstan.png';
-import armenia from '../images/armenia.png';
-import belarus from '../images/belarus.png';
-import kyrgyzstan from '../images/kyrgyzstan.png';
-import azerbaijan from '../images/azerbaijan.png';
-import georgia from '../images/georgia.png';
-import moldova from '../images/moldova.png';
-import tajikistan from '../images/tajikistan.png';
-import turkmenistan from '../images/turkmenistan.png';
-import uzbekistan from '../images/uzbekistan.png';
-import ukraine from '../images/ukraine.png';
-import other from '../images/other.png';
+import type { PhoneInputMask } from "../types";
+import russia from "../images/russia.png";
+import kazakhstan from "../images/kazakhstan.png";
+import armenia from "../images/armenia.png";
+import belarus from "../images/belarus.png";
+import kyrgyzstan from "../images/kyrgyzstan.png";
+import azerbaijan from "../images/azerbaijan.png";
+import georgia from "../images/georgia.png";
+import moldova from "../images/moldova.png";
+import tajikistan from "../images/tajikistan.png";
+import turkmenistan from "../images/turkmenistan.png";
+import uzbekistan from "../images/uzbekistan.png";
+import ukraine from "../images/ukraine.png";
+import other from "../images/other.png";
 
 export const masks: PhoneInputMask[] = [
   {
-    id: 'russia',
-    title: 'Россия',
-    mask: '+7 (___) ___-__-__',
+    id: "russia",
+    title: "Россия",
+    mask: "+7 (___) ___-__-__",
     optionImageSrc: russia,
-    optionEndContent: '+7',
+    optionEndContent: "+7",
   },
   {
-    id: 'kazakhstan',
-    title: 'Казахстан',
-    mask: '+7 (___) ___-__-__',
+    id: "kazakhstan",
+    title: "Казахстан",
+    mask: "+7 (___) ___-__-__",
     optionImageSrc: kazakhstan,
-    optionEndContent: '+7',
+    optionEndContent: "+7",
   },
   {
-    id: 'armenia',
-    title: 'Армения',
-    mask: '+374-__-___-___',
+    id: "armenia",
+    title: "Армения",
+    mask: "+374-__-___-___",
     optionImageSrc: armenia,
-    optionEndContent: '+374',
+    optionEndContent: "+374",
   },
   {
-    id: 'belarus',
-    title: 'Беларусь',
-    mask: '+375 (__) ___-__-__',
+    id: "belarus",
+    title: "Беларусь",
+    mask: "+375 (__) ___-__-__",
     optionImageSrc: belarus,
-    optionEndContent: '+375',
+    optionEndContent: "+375",
   },
   {
-    id: 'kyrgyzstan',
-    title: 'Кыргызстан',
-    mask: '+996 (___) ___-___',
+    id: "kyrgyzstan",
+    title: "Кыргызстан",
+    mask: "+996 (___) ___-___",
     optionImageSrc: kyrgyzstan,
-    optionEndContent: '+996',
+    optionEndContent: "+996",
   },
   {
-    id: 'azerbaijan',
-    title: 'Азербайджан',
-    mask: '+994-__-___-__-__',
+    id: "azerbaijan",
+    title: "Азербайджан",
+    mask: "+994-__-___-__-__",
     optionImageSrc: azerbaijan,
-    optionEndContent: '+994',
+    optionEndContent: "+994",
   },
   {
-    id: 'georgia',
-    title: 'Грузия',
-    mask: '+995 (___) ___-___',
+    id: "georgia",
+    title: "Грузия",
+    mask: "+995 (___) ___-___",
     optionImageSrc: georgia,
-    optionEndContent: '+995',
+    optionEndContent: "+995",
   },
   {
-    id: 'moldova',
-    title: 'Молдова',
-    mask: '+373-____-____',
+    id: "moldova",
+    title: "Молдова",
+    mask: "+373-____-____",
     optionImageSrc: moldova,
-    optionEndContent: '+373',
+    optionEndContent: "+373",
   },
   {
-    id: 'tajikistan',
-    title: 'Таджикистан',
-    mask: '+992-__-___-____',
+    id: "tajikistan",
+    title: "Таджикистан",
+    mask: "+992-__-___-____",
     optionImageSrc: tajikistan,
-    optionEndContent: '+992',
+    optionEndContent: "+992",
   },
   {
-    id: 'turkmenistan',
-    title: 'Туркмения',
-    mask: '+993-_-___-____',
+    id: "turkmenistan",
+    title: "Туркмения",
+    mask: "+993-_-___-____",
     optionImageSrc: turkmenistan,
-    optionEndContent: '+993',
+    optionEndContent: "+993",
   },
   {
-    id: 'uzbekistan',
-    title: 'Узбекистан',
-    mask: '+998-__-___-____',
+    id: "uzbekistan",
+    title: "Узбекистан",
+    mask: "+998-__-___-____",
     optionImageSrc: uzbekistan,
-    optionEndContent: '+998',
+    optionEndContent: "+998",
   },
   {
-    id: 'ukraine',
-    title: 'Украина',
-    mask: '+380 (__) ___-__-__',
+    id: "ukraine",
+    title: "Украина",
+    mask: "+380 (__) ___-__-__",
     optionImageSrc: ukraine,
-    optionEndContent: '+380',
+    optionEndContent: "+380",
   },
   {
-    id: 'other',
-    title: 'Другое',
-    mask: '_______________',
+    id: "other",
+    title: "Другое",
+    mask: "_______________",
     needRestPlaceholder: false,
     optionImageSrc: other,
+    filledMaskMinLength: 5,
   },
 ];

--- a/src/phone-input/preset/defaults-import-png.ts
+++ b/src/phone-input/preset/defaults-import-png.ts
@@ -1,107 +1,107 @@
-import type { PhoneInputMask } from "../types";
-import russia from "../images/russia.png";
-import kazakhstan from "../images/kazakhstan.png";
-import armenia from "../images/armenia.png";
-import belarus from "../images/belarus.png";
-import kyrgyzstan from "../images/kyrgyzstan.png";
-import azerbaijan from "../images/azerbaijan.png";
-import georgia from "../images/georgia.png";
-import moldova from "../images/moldova.png";
-import tajikistan from "../images/tajikistan.png";
-import turkmenistan from "../images/turkmenistan.png";
-import uzbekistan from "../images/uzbekistan.png";
-import ukraine from "../images/ukraine.png";
-import other from "../images/other.png";
+import type { PhoneInputMask } from '../types';
+import russia from '../images/russia.png';
+import kazakhstan from '../images/kazakhstan.png';
+import armenia from '../images/armenia.png';
+import belarus from '../images/belarus.png';
+import kyrgyzstan from '../images/kyrgyzstan.png';
+import azerbaijan from '../images/azerbaijan.png';
+import georgia from '../images/georgia.png';
+import moldova from '../images/moldova.png';
+import tajikistan from '../images/tajikistan.png';
+import turkmenistan from '../images/turkmenistan.png';
+import uzbekistan from '../images/uzbekistan.png';
+import ukraine from '../images/ukraine.png';
+import other from '../images/other.png';
 
 export const masks: PhoneInputMask[] = [
   {
-    id: "russia",
-    title: "Россия",
-    mask: "+7 (___) ___-__-__",
+    id: 'russia',
+    title: 'Россия',
+    mask: '+7 (___) ___-__-__',
     optionImageSrc: russia,
-    optionEndContent: "+7",
+    optionEndContent: '+7',
   },
   {
-    id: "kazakhstan",
-    title: "Казахстан",
-    mask: "+7 (___) ___-__-__",
+    id: 'kazakhstan',
+    title: 'Казахстан',
+    mask: '+7 (___) ___-__-__',
     optionImageSrc: kazakhstan,
-    optionEndContent: "+7",
+    optionEndContent: '+7',
   },
   {
-    id: "armenia",
-    title: "Армения",
-    mask: "+374-__-___-___",
+    id: 'armenia',
+    title: 'Армения',
+    mask: '+374-__-___-___',
     optionImageSrc: armenia,
-    optionEndContent: "+374",
+    optionEndContent: '+374',
   },
   {
-    id: "belarus",
-    title: "Беларусь",
-    mask: "+375 (__) ___-__-__",
+    id: 'belarus',
+    title: 'Беларусь',
+    mask: '+375 (__) ___-__-__',
     optionImageSrc: belarus,
-    optionEndContent: "+375",
+    optionEndContent: '+375',
   },
   {
-    id: "kyrgyzstan",
-    title: "Кыргызстан",
-    mask: "+996 (___) ___-___",
+    id: 'kyrgyzstan',
+    title: 'Кыргызстан',
+    mask: '+996 (___) ___-___',
     optionImageSrc: kyrgyzstan,
-    optionEndContent: "+996",
+    optionEndContent: '+996',
   },
   {
-    id: "azerbaijan",
-    title: "Азербайджан",
-    mask: "+994-__-___-__-__",
+    id: 'azerbaijan',
+    title: 'Азербайджан',
+    mask: '+994-__-___-__-__',
     optionImageSrc: azerbaijan,
-    optionEndContent: "+994",
+    optionEndContent: '+994',
   },
   {
-    id: "georgia",
-    title: "Грузия",
-    mask: "+995 (___) ___-___",
+    id: 'georgia',
+    title: 'Грузия',
+    mask: '+995 (___) ___-___',
     optionImageSrc: georgia,
-    optionEndContent: "+995",
+    optionEndContent: '+995',
   },
   {
-    id: "moldova",
-    title: "Молдова",
-    mask: "+373-____-____",
+    id: 'moldova',
+    title: 'Молдова',
+    mask: '+373-____-____',
     optionImageSrc: moldova,
-    optionEndContent: "+373",
+    optionEndContent: '+373',
   },
   {
-    id: "tajikistan",
-    title: "Таджикистан",
-    mask: "+992-__-___-____",
+    id: 'tajikistan',
+    title: 'Таджикистан',
+    mask: '+992-__-___-____',
     optionImageSrc: tajikistan,
-    optionEndContent: "+992",
+    optionEndContent: '+992',
   },
   {
-    id: "turkmenistan",
-    title: "Туркмения",
-    mask: "+993-_-___-____",
+    id: 'turkmenistan',
+    title: 'Туркмения',
+    mask: '+993-_-___-____',
     optionImageSrc: turkmenistan,
-    optionEndContent: "+993",
+    optionEndContent: '+993',
   },
   {
-    id: "uzbekistan",
-    title: "Узбекистан",
-    mask: "+998-__-___-____",
+    id: 'uzbekistan',
+    title: 'Узбекистан',
+    mask: '+998-__-___-____',
     optionImageSrc: uzbekistan,
-    optionEndContent: "+998",
+    optionEndContent: '+998',
   },
   {
-    id: "ukraine",
-    title: "Украина",
-    mask: "+380 (__) ___-__-__",
+    id: 'ukraine',
+    title: 'Украина',
+    mask: '+380 (__) ___-__-__',
     optionImageSrc: ukraine,
-    optionEndContent: "+380",
+    optionEndContent: '+380',
   },
   {
-    id: "other",
-    title: "Другое",
-    mask: "_______________",
+    id: 'other',
+    title: 'Другое',
+    mask: '_______________',
     needRestPlaceholder: false,
     optionImageSrc: other,
     filledMaskMinLength: 5,

--- a/src/phone-input/preset/defaults.ts
+++ b/src/phone-input/preset/defaults.ts
@@ -1,115 +1,115 @@
-import type { PhoneInputMask } from "../types";
-import russia from "../images/russia";
-import kazakhstan from "../images/kazakhstan";
-import armenia from "../images/armenia";
-import belarus from "../images/belarus";
-import kyrgyzstan from "../images/kyrgyzstan";
-import azerbaijan from "../images/azerbaijan";
-import georgia from "../images/georgia";
-import moldova from "../images/moldova";
-import tajikistan from "../images/tajikistan";
-import turkmenistan from "../images/turkmenistan";
-import uzbekistan from "../images/uzbekistan";
-import ukraine from "../images/ukraine";
-import other from "../images/other";
+import type { PhoneInputMask } from '../types';
+import russia from '../images/russia';
+import kazakhstan from '../images/kazakhstan';
+import armenia from '../images/armenia';
+import belarus from '../images/belarus';
+import kyrgyzstan from '../images/kyrgyzstan';
+import azerbaijan from '../images/azerbaijan';
+import georgia from '../images/georgia';
+import moldova from '../images/moldova';
+import tajikistan from '../images/tajikistan';
+import turkmenistan from '../images/turkmenistan';
+import uzbekistan from '../images/uzbekistan';
+import ukraine from '../images/ukraine';
+import other from '../images/other';
 
 export const stubMask: PhoneInputMask = {
-  id: "other",
-  title: "Другое",
-  mask: "_______________",
+  id: 'other',
+  title: 'Другое',
+  mask: '_______________',
   needRestPlaceholder: false,
   optionImageSrc: other,
   filledMaskMinLength: 5,
 };
 
 export const russiaMask: PhoneInputMask = {
-  id: "russia",
-  title: "Россия",
-  mask: "+7 (___) ___-__-__",
+  id: 'russia',
+  title: 'Россия',
+  mask: '+7 (___) ___-__-__',
   optionImageSrc: russia,
-  optionEndContent: "+7",
+  optionEndContent: '+7',
 };
 
 export const kazakhstanMask: PhoneInputMask = {
-  id: "kazakhstan",
-  title: "Казахстан",
-  mask: "+7 (___) ___-__-__",
+  id: 'kazakhstan',
+  title: 'Казахстан',
+  mask: '+7 (___) ___-__-__',
   optionImageSrc: kazakhstan,
-  optionEndContent: "+7",
+  optionEndContent: '+7',
 };
 
 export const masks: PhoneInputMask[] = [
   russiaMask,
   kazakhstanMask,
   {
-    id: "armenia",
-    title: "Армения",
-    mask: "+374-__-___-___",
+    id: 'armenia',
+    title: 'Армения',
+    mask: '+374-__-___-___',
     optionImageSrc: armenia,
-    optionEndContent: "+374",
+    optionEndContent: '+374',
   },
   {
-    id: "belarus",
-    title: "Беларусь",
-    mask: "+375 (__) ___-__-__",
+    id: 'belarus',
+    title: 'Беларусь',
+    mask: '+375 (__) ___-__-__',
     optionImageSrc: belarus,
-    optionEndContent: "+375",
+    optionEndContent: '+375',
   },
   {
-    id: "kyrgyzstan",
-    title: "Кыргызстан",
-    mask: "+996 (___) ___-___",
+    id: 'kyrgyzstan',
+    title: 'Кыргызстан',
+    mask: '+996 (___) ___-___',
     optionImageSrc: kyrgyzstan,
-    optionEndContent: "+996",
+    optionEndContent: '+996',
   },
   {
-    id: "azerbaijan",
-    title: "Азербайджан",
-    mask: "+994-__-___-__-__",
+    id: 'azerbaijan',
+    title: 'Азербайджан',
+    mask: '+994-__-___-__-__',
     optionImageSrc: azerbaijan,
-    optionEndContent: "+994",
+    optionEndContent: '+994',
   },
   {
-    id: "georgia",
-    title: "Грузия",
-    mask: "+995 (___) ___-___",
+    id: 'georgia',
+    title: 'Грузия',
+    mask: '+995 (___) ___-___',
     optionImageSrc: georgia,
-    optionEndContent: "+995",
+    optionEndContent: '+995',
   },
   {
-    id: "moldova",
-    title: "Молдова",
-    mask: "+373-____-____",
+    id: 'moldova',
+    title: 'Молдова',
+    mask: '+373-____-____',
     optionImageSrc: moldova,
-    optionEndContent: "+373",
+    optionEndContent: '+373',
   },
   {
-    id: "tajikistan",
-    title: "Таджикистан",
-    mask: "+992-__-___-____",
+    id: 'tajikistan',
+    title: 'Таджикистан',
+    mask: '+992-__-___-____',
     optionImageSrc: tajikistan,
-    optionEndContent: "+992",
+    optionEndContent: '+992',
   },
   {
-    id: "turkmenistan",
-    title: "Туркмения",
-    mask: "+993-_-___-____",
+    id: 'turkmenistan',
+    title: 'Туркмения',
+    mask: '+993-_-___-____',
     optionImageSrc: turkmenistan,
-    optionEndContent: "+993",
+    optionEndContent: '+993',
   },
   {
-    id: "uzbekistan",
-    title: "Узбекистан",
-    mask: "+998-__-___-____",
+    id: 'uzbekistan',
+    title: 'Узбекистан',
+    mask: '+998-__-___-____',
     optionImageSrc: uzbekistan,
-    optionEndContent: "+998",
+    optionEndContent: '+998',
   },
   {
-    id: "ukraine",
-    title: "Украина",
-    mask: "+380 (__) ___-__-__",
+    id: 'ukraine',
+    title: 'Украина',
+    mask: '+380 (__) ___-__-__',
     optionImageSrc: ukraine,
-    optionEndContent: "+380",
+    optionEndContent: '+380',
   },
   stubMask,
 ];

--- a/src/phone-input/preset/defaults.ts
+++ b/src/phone-input/preset/defaults.ts
@@ -1,114 +1,115 @@
-import type { PhoneInputMask } from '../types';
-import russia from '../images/russia';
-import kazakhstan from '../images/kazakhstan';
-import armenia from '../images/armenia';
-import belarus from '../images/belarus';
-import kyrgyzstan from '../images/kyrgyzstan';
-import azerbaijan from '../images/azerbaijan';
-import georgia from '../images/georgia';
-import moldova from '../images/moldova';
-import tajikistan from '../images/tajikistan';
-import turkmenistan from '../images/turkmenistan';
-import uzbekistan from '../images/uzbekistan';
-import ukraine from '../images/ukraine';
-import other from '../images/other';
+import type { PhoneInputMask } from "../types";
+import russia from "../images/russia";
+import kazakhstan from "../images/kazakhstan";
+import armenia from "../images/armenia";
+import belarus from "../images/belarus";
+import kyrgyzstan from "../images/kyrgyzstan";
+import azerbaijan from "../images/azerbaijan";
+import georgia from "../images/georgia";
+import moldova from "../images/moldova";
+import tajikistan from "../images/tajikistan";
+import turkmenistan from "../images/turkmenistan";
+import uzbekistan from "../images/uzbekistan";
+import ukraine from "../images/ukraine";
+import other from "../images/other";
 
 export const stubMask: PhoneInputMask = {
-  id: 'other',
-  title: 'Другое',
-  mask: '_______________',
+  id: "other",
+  title: "Другое",
+  mask: "_______________",
   needRestPlaceholder: false,
   optionImageSrc: other,
+  filledMaskMinLength: 5,
 };
 
 export const russiaMask: PhoneInputMask = {
-  id: 'russia',
-  title: 'Россия',
-  mask: '+7 (___) ___-__-__',
+  id: "russia",
+  title: "Россия",
+  mask: "+7 (___) ___-__-__",
   optionImageSrc: russia,
-  optionEndContent: '+7',
+  optionEndContent: "+7",
 };
 
 export const kazakhstanMask: PhoneInputMask = {
-  id: 'kazakhstan',
-  title: 'Казахстан',
-  mask: '+7 (___) ___-__-__',
+  id: "kazakhstan",
+  title: "Казахстан",
+  mask: "+7 (___) ___-__-__",
   optionImageSrc: kazakhstan,
-  optionEndContent: '+7',
+  optionEndContent: "+7",
 };
 
 export const masks: PhoneInputMask[] = [
   russiaMask,
   kazakhstanMask,
   {
-    id: 'armenia',
-    title: 'Армения',
-    mask: '+374-__-___-___',
+    id: "armenia",
+    title: "Армения",
+    mask: "+374-__-___-___",
     optionImageSrc: armenia,
-    optionEndContent: '+374',
+    optionEndContent: "+374",
   },
   {
-    id: 'belarus',
-    title: 'Беларусь',
-    mask: '+375 (__) ___-__-__',
+    id: "belarus",
+    title: "Беларусь",
+    mask: "+375 (__) ___-__-__",
     optionImageSrc: belarus,
-    optionEndContent: '+375',
+    optionEndContent: "+375",
   },
   {
-    id: 'kyrgyzstan',
-    title: 'Кыргызстан',
-    mask: '+996 (___) ___-___',
+    id: "kyrgyzstan",
+    title: "Кыргызстан",
+    mask: "+996 (___) ___-___",
     optionImageSrc: kyrgyzstan,
-    optionEndContent: '+996',
+    optionEndContent: "+996",
   },
   {
-    id: 'azerbaijan',
-    title: 'Азербайджан',
-    mask: '+994-__-___-__-__',
+    id: "azerbaijan",
+    title: "Азербайджан",
+    mask: "+994-__-___-__-__",
     optionImageSrc: azerbaijan,
-    optionEndContent: '+994',
+    optionEndContent: "+994",
   },
   {
-    id: 'georgia',
-    title: 'Грузия',
-    mask: '+995 (___) ___-___',
+    id: "georgia",
+    title: "Грузия",
+    mask: "+995 (___) ___-___",
     optionImageSrc: georgia,
-    optionEndContent: '+995',
+    optionEndContent: "+995",
   },
   {
-    id: 'moldova',
-    title: 'Молдова',
-    mask: '+373-____-____',
+    id: "moldova",
+    title: "Молдова",
+    mask: "+373-____-____",
     optionImageSrc: moldova,
-    optionEndContent: '+373',
+    optionEndContent: "+373",
   },
   {
-    id: 'tajikistan',
-    title: 'Таджикистан',
-    mask: '+992-__-___-____',
+    id: "tajikistan",
+    title: "Таджикистан",
+    mask: "+992-__-___-____",
     optionImageSrc: tajikistan,
-    optionEndContent: '+992',
+    optionEndContent: "+992",
   },
   {
-    id: 'turkmenistan',
-    title: 'Туркмения',
-    mask: '+993-_-___-____',
+    id: "turkmenistan",
+    title: "Туркмения",
+    mask: "+993-_-___-____",
     optionImageSrc: turkmenistan,
-    optionEndContent: '+993',
+    optionEndContent: "+993",
   },
   {
-    id: 'uzbekistan',
-    title: 'Узбекистан',
-    mask: '+998-__-___-____',
+    id: "uzbekistan",
+    title: "Узбекистан",
+    mask: "+998-__-___-____",
     optionImageSrc: uzbekistan,
-    optionEndContent: '+998',
+    optionEndContent: "+998",
   },
   {
-    id: 'ukraine',
-    title: 'Украина',
-    mask: '+380 (__) ___-__-__',
+    id: "ukraine",
+    title: "Украина",
+    mask: "+380 (__) ___-__-__",
     optionImageSrc: ukraine,
-    optionEndContent: '+380',
+    optionEndContent: "+380",
   },
   stubMask,
 ];

--- a/src/phone-input/types.ts
+++ b/src/phone-input/types.ts
@@ -1,8 +1,8 @@
-import type { DropdownProps } from "../dropdown";
-import type { MaskedInputProps } from "../masked-input";
+import type { DropdownProps } from '../dropdown';
+import type { MaskedInputProps } from '../masked-input';
 
 export interface PhoneInputProps
-  extends Omit<MaskedInputProps, "mask" | "placeholder" | "pattern"> {
+  extends Omit<MaskedInputProps, 'mask' | 'placeholder' | 'pattern'> {
   /** Маски номеров телефона. */
   masks?: PhoneInputMask[];
 
@@ -10,7 +10,7 @@ export interface PhoneInputProps
   onCountrySelect?: (country: PhoneInputMask) => void;
 
   /** Свойства компонента Dropdown. */
-  dropdownProps?: Omit<DropdownProps, "rootRef" | "viewportRef">;
+  dropdownProps?: Omit<DropdownProps, 'rootRef' | 'viewportRef'>;
 
   /** Сработает при открытии меню. */
   onMenuOpen?: VoidFunction;
@@ -26,19 +26,19 @@ export interface PhoneInputProps
 }
 
 export type MaskId =
-  | "russia"
-  | "kazakhstan"
-  | "armenia"
-  | "belarus"
-  | "kyrgyzstan"
-  | "azerbaijan"
-  | "georgia"
-  | "moldova"
-  | "tajikistan"
-  | "turkmenistan"
-  | "uzbekistan"
-  | "ukraine"
-  | "other";
+  | 'russia'
+  | 'kazakhstan'
+  | 'armenia'
+  | 'belarus'
+  | 'kyrgyzstan'
+  | 'azerbaijan'
+  | 'georgia'
+  | 'moldova'
+  | 'tajikistan'
+  | 'turkmenistan'
+  | 'uzbekistan'
+  | 'ukraine'
+  | 'other';
 
 export interface PhoneInputMask {
   /** Идентификатор. */

--- a/src/phone-input/types.ts
+++ b/src/phone-input/types.ts
@@ -1,8 +1,8 @@
-import type { DropdownProps } from '../dropdown';
-import type { MaskedInputProps } from '../masked-input';
+import type { DropdownProps } from "../dropdown";
+import type { MaskedInputProps } from "../masked-input";
 
 export interface PhoneInputProps
-  extends Omit<MaskedInputProps, 'mask' | 'placeholder' | 'pattern'> {
+  extends Omit<MaskedInputProps, "mask" | "placeholder" | "pattern"> {
   /** Маски номеров телефона. */
   masks?: PhoneInputMask[];
 
@@ -10,7 +10,7 @@ export interface PhoneInputProps
   onCountrySelect?: (country: PhoneInputMask) => void;
 
   /** Свойства компонента Dropdown. */
-  dropdownProps?: Omit<DropdownProps, 'rootRef' | 'viewportRef'>;
+  dropdownProps?: Omit<DropdownProps, "rootRef" | "viewportRef">;
 
   /** Сработает при открытии меню. */
   onMenuOpen?: VoidFunction;
@@ -25,8 +25,24 @@ export interface PhoneInputProps
   }) => PhoneInputMask | undefined;
 }
 
+export type MaskId =
+  | "russia"
+  | "kazakhstan"
+  | "armenia"
+  | "belarus"
+  | "kyrgyzstan"
+  | "azerbaijan"
+  | "georgia"
+  | "moldova"
+  | "tajikistan"
+  | "turkmenistan"
+  | "uzbekistan"
+  | "ukraine"
+  | "other";
+
 export interface PhoneInputMask {
-  readonly id: string;
+  /** Идентификатор. */
+  readonly id: MaskId;
 
   /** Название. */
   readonly title: string;
@@ -38,8 +54,11 @@ export interface PhoneInputMask {
   readonly needRestPlaceholder?: boolean;
 
   /** Картинка. */
-  readonly optionImageSrc?: string;
+  readonly optionImageSrc: string;
 
   /** Дополнительный текст. */
   readonly optionEndContent?: string;
+
+  /** Минимальное допустимое количество символов для расчета заполненности маски. */
+  readonly filledMaskMinLength?: number;
 }

--- a/tests/phone-input.spec.ts
+++ b/tests/phone-input.spec.ts
@@ -1,40 +1,42 @@
-import { test, expect } from '@playwright/test';
-import { TestUtils } from './utils';
+import { test, expect } from "@playwright/test";
+import { TestUtils } from "./utils";
 
 class Here extends TestUtils {
   phoneInput() {
-    return this.page.getByTestId('phone-input');
+    return this.page.getByTestId("phone-input");
   }
 
   fieldBlock() {
-    return this.phoneInput().getByTestId('field-block:block');
+    return this.phoneInput().getByTestId("field-block:block");
   }
 
   input() {
-    return this.fieldBlock().getByTestId('base-input:field');
+    return this.fieldBlock().getByTestId("base-input:field");
   }
 
   restPlaceholder() {
-    return this.fieldBlock().getByTestId('base-input').getByTestId('rest-placeholder');
+    return this.fieldBlock()
+      .getByTestId("base-input")
+      .getByTestId("rest-placeholder");
   }
 
   menuOpener() {
-    return this.fieldBlock().getByTestId('phone-input:menu-opener');
+    return this.fieldBlock().getByTestId("phone-input:menu-opener");
   }
 
   menu() {
-    return this.page.getByTestId('dropdown');
+    return this.page.getByTestId("dropdown");
   }
 
   menuItem() {
-    return this.menu().getByTestId('dropdown-item');
+    return this.menu().getByTestId("dropdown-item");
   }
 }
 
 const here = new Here().register();
 
-test('Opener must be in page', async ({ page }) => {
-  await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
+test("Opener must be in page", async ({ page }) => {
+  await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
 
   await expect(here.phoneInput()).toHaveCount(1);
   await expect(here.fieldBlock()).toHaveCount(1);
@@ -43,12 +45,12 @@ test('Opener must be in page', async ({ page }) => {
   await expect(here.page).toHaveScreenshot();
 });
 
-test.describe('Mouse interactions', () => {
+test.describe("Mouse interactions", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
+    await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
   });
 
-  test('should handle mouse control', async () => {
+  test("should handle mouse control", async () => {
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
@@ -70,101 +72,105 @@ test.describe('Mouse interactions', () => {
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.menuOpener()).toBeFocused();
-    await expect(here.input()).toHaveValue('+374-');
-    await expect(here.restPlaceholder()).toHaveText('__-___-___');
+    await expect(here.input()).toHaveValue("+374-");
+    await expect(here.restPlaceholder()).toHaveText("__-___-___");
     await expect(here.page).toHaveScreenshot();
   });
 });
 
-test.describe('Keyboard interactions', () => {
+test.describe("Keyboard interactions", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
+    await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
   });
 
-  test('should handle keyboard control', async () => {
+  test("should handle keyboard control", async () => {
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.input()).not.toBeFocused();
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press('Tab');
+    await here.page.keyboard.press("Tab");
     await expect(here.input()).toBeFocused();
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press('Tab');
+    await here.page.keyboard.press("Tab");
     await expect(here.menuOpener()).toBeFocused();
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press('Enter');
+    await here.page.keyboard.press("Enter");
     await expect(here.menu()).toHaveCount(1);
     await expect(here.menuItem()).toHaveCount(13);
     await expect(here.menu()).toBeFocused();
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press('ArrowDown');
-    await here.page.keyboard.press('ArrowDown');
-    await here.page.keyboard.press('ArrowDown');
-    await here.page.keyboard.press('ArrowDown');
-    await here.page.keyboard.press('ArrowDown');
+    await here.page.keyboard.press("ArrowDown");
+    await here.page.keyboard.press("ArrowDown");
+    await here.page.keyboard.press("ArrowDown");
+    await here.page.keyboard.press("ArrowDown");
+    await here.page.keyboard.press("ArrowDown");
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press('Enter');
+    await here.page.keyboard.press("Enter");
     await expect(here.menuOpener()).toBeFocused();
-    await expect(here.input()).toHaveValue('+996 (');
-    await expect(here.restPlaceholder()).toHaveText('___) ___-___');
+    await expect(here.input()).toHaveValue("+996 (");
+    await expect(here.restPlaceholder()).toHaveText("___) ___-___");
     await expect(here.page).toHaveScreenshot();
   });
 });
 
-test.describe('Props handling', () => {
+test.describe("Props handling", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/sandbox.html?path=/components/phone-input/04-different-states');
+    await page.goto(
+      "/sandbox.html?path=/components/phone-input/04-different-states",
+    );
   });
 
   const variants = [
     {
-      event: 'change',
+      event: "change",
       controlled: true,
     },
     {
-      event: 'change',
+      event: "change",
       controlled: false,
     },
     {
-      event: 'input',
+      event: "input",
       controlled: true,
     },
     {
-      event: 'input',
+      event: "input",
       controlled: false,
     },
   ];
 
   for (const { controlled, event } of variants) {
-    test(`Default state with on${event} and ${controlled ? 'value' : 'defaultValue'}`, async () => {
-      await here.page.getByLabel('Состояние').selectOption({ value: 'default' });
-      await here.page.getByLabel('Событие').selectOption({ value: event });
-      await here.page.getByLabel('Контролируемый').setChecked(controlled);
+    test(`Default state with on${event} and ${controlled ? "value" : "defaultValue"}`, async () => {
+      await here.page
+        .getByLabel("Состояние")
+        .selectOption({ value: "default" });
+      await here.page.getByLabel("Событие").selectOption({ value: event });
+      await here.page.getByLabel("Контролируемый").setChecked(controlled);
 
       await expect(here.phoneInput()).toHaveCount(1);
       await expect(here.menu()).toHaveCount(0);
       await expect(here.menuItem()).toHaveCount(0);
       await expect(here.input()).not.toBeFocused();
-      await expect(here.input()).toHaveValue('+7 (800) 555-35-35');
+      await expect(here.input()).toHaveValue("+7 (800) 555-35-35");
 
       await here.phoneInput().click();
       await expect(here.input()).toBeFocused();
 
-      await here.input().fill('');
-      await expect(here.input()).toHaveValue('+7 (');
+      await here.input().clear();
+      await expect(here.input()).toHaveValue("+7 (");
 
-      await here.input().fill('1002003040');
-      await expect(here.input()).toHaveValue('+7 (100) 200-30-40');
+      await here.input().fill("1002003040");
+      await expect(here.input()).toHaveValue("+7 (100) 200-30-40");
 
       await here.menuOpener().click();
       await expect(here.menu()).toHaveCount(1);
@@ -173,27 +179,30 @@ test.describe('Props handling', () => {
       await here.menuItem().nth(6).click();
       await expect(here.menu()).toHaveCount(0);
       await expect(here.menuItem()).toHaveCount(0);
-      await expect(here.input()).toHaveValue('+995 (');
+      await expect(here.input()).toHaveValue("+995 (");
 
       await here.phoneInput().click();
       await expect(here.input()).toBeFocused();
 
-      await here.input().fill('111222333');
-      await expect(here.input()).toHaveValue('+995 (111) 222-333');
+      await here.input().fill("111222333");
+      await expect(here.input()).toHaveValue("+995 (111) 222-333");
     });
   }
 
-  test('Disabled state', async () => {
-    await here.page.getByLabel('Состояние').selectOption({ value: 'disabled' });
+  test("Disabled state", async () => {
+    await here.page.getByLabel("Состояние").selectOption({ value: "disabled" });
 
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.input()).toBeDisabled();
     await expect(here.menuOpener()).toBeDisabled();
-    await expect(here.menuOpener()).toHaveAttribute('role', 'combobox');
-    await expect(here.menuOpener()).toHaveAttribute('aria-label', 'Выбор страны');
-    await expect(here.input()).toHaveValue('+7 (800) 555-35-35');
+    await expect(here.menuOpener()).toHaveAttribute("role", "combobox");
+    await expect(here.menuOpener()).toHaveAttribute(
+      "aria-label",
+      "Выбор страны",
+    );
+    await expect(here.input()).toHaveValue("+7 (800) 555-35-35");
     await expect(here.page).toHaveScreenshot();
 
     await here.menuOpener().click({ force: true });
@@ -203,7 +212,7 @@ test.describe('Props handling', () => {
     await here.menuOpener().focus();
     await expect(here.menuOpener()).not.toBeFocused();
 
-    await here.menuOpener().press('Enter');
+    await here.menuOpener().press("Enter");
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
   });

--- a/tests/phone-input.spec.ts
+++ b/tests/phone-input.spec.ts
@@ -1,42 +1,40 @@
-import { test, expect } from "@playwright/test";
-import { TestUtils } from "./utils";
+import { test, expect } from '@playwright/test';
+import { TestUtils } from './utils';
 
 class Here extends TestUtils {
   phoneInput() {
-    return this.page.getByTestId("phone-input");
+    return this.page.getByTestId('phone-input');
   }
 
   fieldBlock() {
-    return this.phoneInput().getByTestId("field-block:block");
+    return this.phoneInput().getByTestId('field-block:block');
   }
 
   input() {
-    return this.fieldBlock().getByTestId("base-input:field");
+    return this.fieldBlock().getByTestId('base-input:field');
   }
 
   restPlaceholder() {
-    return this.fieldBlock()
-      .getByTestId("base-input")
-      .getByTestId("rest-placeholder");
+    return this.fieldBlock().getByTestId('base-input').getByTestId('rest-placeholder');
   }
 
   menuOpener() {
-    return this.fieldBlock().getByTestId("phone-input:menu-opener");
+    return this.fieldBlock().getByTestId('phone-input:menu-opener');
   }
 
   menu() {
-    return this.page.getByTestId("dropdown");
+    return this.page.getByTestId('dropdown');
   }
 
   menuItem() {
-    return this.menu().getByTestId("dropdown-item");
+    return this.menu().getByTestId('dropdown-item');
   }
 }
 
 const here = new Here().register();
 
-test("Opener must be in page", async ({ page }) => {
-  await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
+test('Opener must be in page', async ({ page }) => {
+  await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
 
   await expect(here.phoneInput()).toHaveCount(1);
   await expect(here.fieldBlock()).toHaveCount(1);
@@ -45,12 +43,12 @@ test("Opener must be in page", async ({ page }) => {
   await expect(here.page).toHaveScreenshot();
 });
 
-test.describe("Mouse interactions", () => {
+test.describe('Mouse interactions', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
+    await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
   });
 
-  test("should handle mouse control", async () => {
+  test('should handle mouse control', async () => {
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
@@ -72,105 +70,101 @@ test.describe("Mouse interactions", () => {
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.menuOpener()).toBeFocused();
-    await expect(here.input()).toHaveValue("+374-");
-    await expect(here.restPlaceholder()).toHaveText("__-___-___");
+    await expect(here.input()).toHaveValue('+374-');
+    await expect(here.restPlaceholder()).toHaveText('__-___-___');
     await expect(here.page).toHaveScreenshot();
   });
 });
 
-test.describe("Keyboard interactions", () => {
+test.describe('Keyboard interactions', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/sandbox.html?path=/components/phone-input/01-primary");
+    await page.goto('/sandbox.html?path=/components/phone-input/01-primary');
   });
 
-  test("should handle keyboard control", async () => {
+  test('should handle keyboard control', async () => {
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.input()).not.toBeFocused();
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press("Tab");
+    await here.page.keyboard.press('Tab');
     await expect(here.input()).toBeFocused();
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press("Tab");
+    await here.page.keyboard.press('Tab');
     await expect(here.menuOpener()).toBeFocused();
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press("Enter");
+    await here.page.keyboard.press('Enter');
     await expect(here.menu()).toHaveCount(1);
     await expect(here.menuItem()).toHaveCount(13);
     await expect(here.menu()).toBeFocused();
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press("ArrowDown");
-    await here.page.keyboard.press("ArrowDown");
-    await here.page.keyboard.press("ArrowDown");
-    await here.page.keyboard.press("ArrowDown");
-    await here.page.keyboard.press("ArrowDown");
+    await here.page.keyboard.press('ArrowDown');
+    await here.page.keyboard.press('ArrowDown');
+    await here.page.keyboard.press('ArrowDown');
+    await here.page.keyboard.press('ArrowDown');
+    await here.page.keyboard.press('ArrowDown');
     await expect(here.page).toHaveScreenshot();
 
-    await here.page.keyboard.press("Enter");
+    await here.page.keyboard.press('Enter');
     await expect(here.menuOpener()).toBeFocused();
-    await expect(here.input()).toHaveValue("+996 (");
-    await expect(here.restPlaceholder()).toHaveText("___) ___-___");
+    await expect(here.input()).toHaveValue('+996 (');
+    await expect(here.restPlaceholder()).toHaveText('___) ___-___');
     await expect(here.page).toHaveScreenshot();
   });
 });
 
-test.describe("Props handling", () => {
+test.describe('Props handling', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(
-      "/sandbox.html?path=/components/phone-input/04-different-states",
-    );
+    await page.goto('/sandbox.html?path=/components/phone-input/04-different-states');
   });
 
   const variants = [
     {
-      event: "change",
+      event: 'change',
       controlled: true,
     },
     {
-      event: "change",
+      event: 'change',
       controlled: false,
     },
     {
-      event: "input",
+      event: 'input',
       controlled: true,
     },
     {
-      event: "input",
+      event: 'input',
       controlled: false,
     },
   ];
 
   for (const { controlled, event } of variants) {
-    test(`Default state with on${event} and ${controlled ? "value" : "defaultValue"}`, async () => {
-      await here.page
-        .getByLabel("Состояние")
-        .selectOption({ value: "default" });
-      await here.page.getByLabel("Событие").selectOption({ value: event });
-      await here.page.getByLabel("Контролируемый").setChecked(controlled);
+    test(`Default state with on${event} and ${controlled ? 'value' : 'defaultValue'}`, async () => {
+      await here.page.getByLabel('Состояние').selectOption({ value: 'default' });
+      await here.page.getByLabel('Событие').selectOption({ value: event });
+      await here.page.getByLabel('Контролируемый').setChecked(controlled);
 
       await expect(here.phoneInput()).toHaveCount(1);
       await expect(here.menu()).toHaveCount(0);
       await expect(here.menuItem()).toHaveCount(0);
       await expect(here.input()).not.toBeFocused();
-      await expect(here.input()).toHaveValue("+7 (800) 555-35-35");
+      await expect(here.input()).toHaveValue('+7 (800) 555-35-35');
 
       await here.phoneInput().click();
       await expect(here.input()).toBeFocused();
 
       await here.input().clear();
-      await expect(here.input()).toHaveValue("+7 (");
+      await expect(here.input()).toHaveValue('+7 (');
 
-      await here.input().fill("1002003040");
-      await expect(here.input()).toHaveValue("+7 (100) 200-30-40");
+      await here.input().fill('1002003040');
+      await expect(here.input()).toHaveValue('+7 (100) 200-30-40');
 
       await here.menuOpener().click();
       await expect(here.menu()).toHaveCount(1);
@@ -179,30 +173,27 @@ test.describe("Props handling", () => {
       await here.menuItem().nth(6).click();
       await expect(here.menu()).toHaveCount(0);
       await expect(here.menuItem()).toHaveCount(0);
-      await expect(here.input()).toHaveValue("+995 (");
+      await expect(here.input()).toHaveValue('+995 (');
 
       await here.phoneInput().click();
       await expect(here.input()).toBeFocused();
 
-      await here.input().fill("111222333");
-      await expect(here.input()).toHaveValue("+995 (111) 222-333");
+      await here.input().fill('111222333');
+      await expect(here.input()).toHaveValue('+995 (111) 222-333');
     });
   }
 
-  test("Disabled state", async () => {
-    await here.page.getByLabel("Состояние").selectOption({ value: "disabled" });
+  test('Disabled state', async () => {
+    await here.page.getByLabel('Состояние').selectOption({ value: 'disabled' });
 
     await expect(here.phoneInput()).toHaveCount(1);
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
     await expect(here.input()).toBeDisabled();
     await expect(here.menuOpener()).toBeDisabled();
-    await expect(here.menuOpener()).toHaveAttribute("role", "combobox");
-    await expect(here.menuOpener()).toHaveAttribute(
-      "aria-label",
-      "Выбор страны",
-    );
-    await expect(here.input()).toHaveValue("+7 (800) 555-35-35");
+    await expect(here.menuOpener()).toHaveAttribute('role', 'combobox');
+    await expect(here.menuOpener()).toHaveAttribute('aria-label', 'Выбор страны');
+    await expect(here.input()).toHaveValue('+7 (800) 555-35-35');
     await expect(here.page).toHaveScreenshot();
 
     await here.menuOpener().click({ force: true });
@@ -212,7 +203,7 @@ test.describe("Props handling", () => {
     await here.menuOpener().focus();
     await expect(here.menuOpener()).not.toBeFocused();
 
-    await here.menuOpener().press("Enter");
+    await here.menuOpener().press('Enter');
     await expect(here.menu()).toHaveCount(0);
     await expect(here.menuItem()).toHaveCount(0);
   });


### PR DESCRIPTION
- `MaskedInput` и `PhoneInput`
  - добавлена логика и возможность прокинуть `prop` для минимального необходимо значения для расчета заполнености маски
  - дефолтное значение для маски `Другое`  == `5 символов`
  - сужен тип для `id` маски и добавлены недостающие экспорты

- `сборка и конфиг`
  - поправлен тип для картинок
  - обновлен `prettier`, т.к `pre-commit hook` подменял `singleQuote` на `doubleQuote`
  - прогнан `audit fix`
