### PR TITLE
Исправлена логика поведения хука useBreakpoint (#519)

### DIFF
--- a/src/hooks/use-breakpoint/index.tsx
+++ b/src/hooks/use-breakpoint/index.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from 'react';
 import { useIsomorphicLayoutEffect } from '..';
-import { isBrowser } from '../../helpers/is-browser';
+import { isBrowser } from '../../helpers';
 import { Registry } from './types';
 import { BreakpointQuery, createRegistry } from './utils';
 import { MatchMediaContext } from '../../context';
@@ -35,11 +35,12 @@ export function useBreakpoint(query: string): boolean {
     throw Error(`useBreakpoint: Invalid query, "${query}"`);
   }
 
+  const { matchMedia } = useContext(MatchMediaContext);
   const [, setRegistry] = useState<Registry | null>(null);
   const registryFromContext = useContext(Context);
-  const [matches, setMatches] = useState<boolean>(false);
-
-  const { matchMedia } = useContext(MatchMediaContext);
+  const [matches, setMatches] = useState<boolean>(
+    matchMedia(BreakpointQuery.toMediaQuery(query)).matches,
+  );
 
   useIsomorphicLayoutEffect(() => {
     let registry: Registry;


### PR DESCRIPTION
Подробности описаны в задаче: https://github.com/sima-land/ui-nucleons/issues/519

Тестов нет потому что не был найден способ тестирования этой функциональности.

Документация testing-library [говорит](https://testing-library.com/docs/react-testing-library/api#result), что в тесте предоставляется результат последнего изменения, после срабатывания всех эффектов. Однако, в данном случае нужно проверить промежуточные результаты и существующий инструментарий не предоставляет никакой возможности это сделать. По крайней мере я таких способов не обнаружил.

Тем не менее, в результате стартовое значение рассчитывается корректно:

<img width="726" height="526" alt="image" src="https://github.com/user-attachments/assets/33fd1891-e71e-45fa-967d-bd1ea56c0424" />


---

feat(useBreakpoint): Исправлена логика поведения хука useBreakpoint (#519)
